### PR TITLE
[master] RevisionGraph: Give numbers of the selection order

### DIFF
--- a/src/TortoiseProc/RevisionGraph/RevisionGraphDlgDraw.cpp
+++ b/src/TortoiseProc/RevisionGraph/RevisionGraphDlgDraw.cpp
@@ -815,11 +815,30 @@ void CRevisionGraphWnd::DrawMarker
 	, const RectF& noderect
 	, MarkerPosition /*position*/
 	, int /*relPosition*/
-	, Color &penColor)
+	, Color &penColor
+	, int num)
 {
 	REAL width = 4*this->m_fZoomFactor<1? 1: 4*this->m_fZoomFactor;
 	Pen pen(penColor,width);
 	DrawRoundedRect(graphics, penColor, (int)width, &pen, Color(0,0,0), NULL, noderect);
+	if (num == 1)
+	{
+		// Roman number 1
+		REAL x = max(1, 10 * this->m_fZoomFactor);
+		REAL y1 = max(1, 25 * this->m_fZoomFactor);
+		REAL y2 = max(1, 5 * this->m_fZoomFactor);
+		graphics.graphics->DrawLine(&pen, noderect.X + x, noderect.Y - y1, noderect.X + x, noderect.Y - y2);
+	}
+	else if (num == 2)
+	{
+		// Roman number 2
+		REAL x1 = max(1, 5 * this->m_fZoomFactor);
+		REAL x2 = max(1, 15 * this->m_fZoomFactor);
+		REAL y1 = max(1, 25 * this->m_fZoomFactor);
+		REAL y2 = max(1, 5 * this->m_fZoomFactor);
+		graphics.graphics->DrawLine(&pen, noderect.X + x1, noderect.Y - y1, noderect.X + x1, noderect.Y - y2);
+		graphics.graphics->DrawLine(&pen, noderect.X + x2, noderect.Y - y1, noderect.X + x2, noderect.Y - y2);
+	}
 }
 
 #if 0
@@ -1244,10 +1263,10 @@ void CRevisionGraphWnd::DrawTexts (GraphicsDevice& graphics, const CRect& /*logR
 			}
 		}
 		if ((m_SelectedEntry1 == v))
-			DrawMarker (graphics, noderect, mpLeft, 0, Color(0,0, 255));
+			DrawMarker(graphics, noderect, mpLeft, 0, Color(0,0, 255), 1);
 
 		if ((m_SelectedEntry2 == v))
-			DrawMarker (graphics, noderect, mpLeft, 0, Color(136,0, 21));
+			DrawMarker(graphics, noderect, mpLeft, 0, Color(136,0, 21), 2);
 
 	}
 }

--- a/src/TortoiseProc/RevisionGraph/RevisionGraphWnd.h
+++ b/src/TortoiseProc/RevisionGraph/RevisionGraphWnd.h
@@ -391,7 +391,7 @@ private:
 	void			DrawGlyphs (GraphicsDevice& graphics, Image* glyphs, const CVisibleGraphNode* node, const RectF& nodeRect,
 								DWORD state, DWORD allowed, bool upsideDown);
 	void			DrawMarker ( GraphicsDevice& graphics, const RectF& noderect
-							   , MarkerPosition position, int relPosition, Color &penColor);
+							   , MarkerPosition position, int relPosition, Color &penColor, int num);
 //	void			IndicateGlyphDirection ( GraphicsDevice& graphics, const ILayoutNodeList* nodeList
 //										 , const ILayoutNodeList::SNode& node, const RectF& nodeRect
 //										 , DWORD glyphs, bool upsideDown, const CSize& offset);


### PR DESCRIPTION
The selection order is also shown in numbers (I or II)

![RevisionGraphSelectedNumber](https://f.cloud.github.com/assets/2804967/29882/cf59922a-4dd9-11e2-85e4-48ab86f98143.png)
