### PR TITLE
Ask set tagopt no tags

### DIFF
--- a/Languages/Tortoise.pot
+++ b/Languages/Tortoise.pot
@@ -8579,6 +8579,10 @@ msgstr ""
 msgid "To"
 msgstr ""
 
+#. Resource IDs: (1422)
+msgid "To avoid fetching wrong tags, if this is not an official remote,\nyou are advised to disable tag fetching for this remote.\nDisable tag fetching?"
+msgstr ""
+
 #. Resource IDs: (606)
 msgid "To clear temporary files, you should ensure that no other TortoiseGit applications are running."
 msgstr ""

--- a/src/Changelog.txt
+++ b/src/Changelog.txt
@@ -5,6 +5,7 @@ Released: Unreleased
  * Fixed issue #1831: Allow Origin Remote Renaming on Clone
  * Fixed issue #1839: Conflict dialog does not allow resolving multiple or all conflicts with the same option
  * Allow to send (patch)mails over relay servers (e.g. the one from your ISP)
+ * When adding second and more remotes, prompt user to disable tag fetching to avoid fetching wrong tags
 
 = Release 1.8.4.0 =
 Released: 2013-07-09

--- a/src/Resources/TortoiseProcENG.rc
+++ b/src/Resources/TortoiseProcENG.rc
@@ -4086,6 +4086,8 @@ BEGIN
     IDS_CARE_SUBMODULE_CHANGES "take care of submodule changes"
     IDS_STATUSLIST_WARN_MAXDIFF 
                             "You have selected %d items to show the diff for.\nFor every of these items a new instance of the diff viewer will be started.\nDo you really want to show the diff for so many items at once?"
+    IDS_PROC_GITCONFIG_ASKTAGOPT 
+                            "To avoid fetching wrong tags, if this is not an official remote,\nyou are advised to disable tag fetching for this remote.\nDisable tag fetching?"
 END
 
 #endif    // English (U.S.) resources

--- a/src/TortoiseProc/Settings/SettingGitRemote.cpp
+++ b/src/TortoiseProc/Settings/SettingGitRemote.cpp
@@ -310,6 +310,17 @@ BOOL CSettingGitRemote::OnApply()
 			CMessageBox::Show(NULL, IDS_PROC_GITCONFIG_URLEMPTY, IDS_APPNAME, MB_OK | MB_ICONERROR);
 			return FALSE;
 		}
+
+		if (m_ctrlRemoteList.GetCount() > 0)
+		{
+			// tagopt not --no-tags
+			if (m_ctrlTagOpt.GetCurSel() != 1)
+			{
+				if (CMessageBox::ShowCheck(GetSafeHwnd(), IDS_PROC_GITCONFIG_ASKTAGOPT, IDS_APPNAME, MB_YESNO | MB_ICONQUESTION, _T("TagOptNoTagsWarning"), IDS_MSGBOX_DONOTSHOWAGAIN) == IDYES)
+					m_ctrlTagOpt.SetCurSel(1);
+			}
+		}
+
 		m_strUrl.Replace(L'\\', L'/');
 		CString cmd,out;
 		cmd.Format(_T("git.exe remote add \"%s\" \"%s\""),m_strRemote,m_strUrl);

--- a/src/TortoiseProc/resource.h
+++ b/src/TortoiseProc/resource.h
@@ -918,6 +918,7 @@
 #define IDS_SMTP_MAPI                   1427
 #define IDC_MAXLINES                    1428
 #define IDS_SMTP_DIRECTLY               1428
+#define IDS_PROC_GITCONFIG_ASKTAGOPT    1429
 #define IDC_DEFAULTOFFLINE              1431
 #define IDC_SHOWIGNOREDOVERLAY          1432
 #define IDC_NONINTERACTIVE              1432


### PR DESCRIPTION
If more than one remote, then probably not adding an official remote.
prompt to disable tag fetching.
Otherwise, when git push --tags, you may push wrong tags.
