### PR TITLE
Add optional support for github-windows and smartgit protocol handlers

### DIFF
--- a/src/TortoiseGitSetup/FeaturesFragment.wxi
+++ b/src/TortoiseGitSetup/FeaturesFragment.wxi
@@ -87,8 +87,16 @@
 			<ComponentRef Id="C__TortoiseUDiffAssoc" />
 		</Feature>
 
-		<Feature Id="ProtocolAssocGit" Level="1" Title="Register git://-link handlers" Description="Associate git://-links with TortoiseGit clone command" TypicalDefault="install" Absent="allow">
-			<ComponentRef Id="ProtocolGit"/>
+		<Feature Id="ProtocolAssoc" Level="1" Title="Register link handlers" Description="Select which protocol-links to associate with TortoiseGit clone command" TypicalDefault="install" Absent="allow" Display="expand">
+			<Feature Id="ProtocolAssocGit" Level="1" Title="Register git://-link handler" Description="Associate git://-links with TortoiseGit clone command" TypicalDefault="install" Absent="allow">
+				<ComponentRef Id="ProtocolGit"/>
+			</Feature>
+			<Feature Id="ProtocolAssocGithub" Level="4" Title="Register github-windows://-link handler" Description="Associate github-windows://-links with TortoiseGit clone command" TypicalDefault="install" Absent="allow">
+				<ComponentRef Id="ProtocolGithub"/>
+			</Feature>
+			<Feature Id="ProtocolAssocSmartgit" Level="4" Title="Register smartgit://-link handler" Description="Associate smartgit://-links with TortoiseGit clone command" TypicalDefault="install" Absent="allow">
+				<ComponentRef Id="ProtocolSmartgit"/>
+			</Feature>
 		</Feature>
 
 		<?if $(var.DictionaryENGB) = 1 ?>

--- a/src/TortoiseGitSetup/Includes.wxi
+++ b/src/TortoiseGitSetup/Includes.wxi
@@ -94,6 +94,8 @@
 	<?define GuidTortoiseUDiffAssoc="1A2972B9-F6B2-4dd5-B656-30638ACCF205"?>
 	<?define GuidProtocolTGit="59646B9D-5524-4236-83E4-2A2D88175ED4"?>
 	<?define GuidProtocolGit="0AD2B787-A9B3-4ad7-99A5-EC6DFF0EB2B7"?>
+	<?define GuidProtocolGithub="78544CC9-8E07-4968-BD03-2D3260301784"?>
+	<?define GuidProtocolSmartgit="294096FE-7AD3-445C-8F7C-77B048315FB9"?>
 	<?define GuidPlainSettingsShortcuts="D78CE764-1770-4d38-9229-F5068D8738FD"?>
 	<?define GuidPlatformSettingsShortcuts="256F134F-87F1-418f-BA9A-AFA92270D42D"?>
 
@@ -163,6 +165,8 @@
 	<?define GuidTortoiseUDiffAssoc="6CF22556-FE5B-4640-A184-D60C5B6AEBE7"?>
 	<?define GuidProtocolTGit="83AEB17F-36A5-4FE1-90DA-57904A085A98"?>
 	<?define GuidProtocolGit="508DD925-273C-4170-9D81-55222E2E36AB"?>
+	<?define GuidProtocolGithub="02D10663-4B9B-4164-B6DA-6EC8BC222A92"?>
+	<?define GuidProtocolSmartgit="C114A9E4-2427-4435-B3BE-11EDC9C39B8C"?>
 	<?define GuidPlainSettingsShortcuts="49263747-C09E-4ffe-A0A4-8E8966CBD807"?>
 	<?define GuidPlatformSettingsShortcuts="F1B92E39-6F75-4ed4-9099-CB5DC7A91831"?>
 

--- a/src/TortoiseGitSetup/StructureFragment.wxi
+++ b/src/TortoiseGitSetup/StructureFragment.wxi
@@ -623,6 +623,18 @@
 						<RegistryValue Root="HKLM" Key="Software\Classes\git\DefaultIcon" Value="[INSTALLDIR]bin\TortoiseGitProc.exe" Type="string" />
 						<RegistryValue Root="HKLM" Key="Software\Classes\git\shell\open\command" Value="&quot;[INSTALLDIR]bin\TortoiseGitProc.exe&quot; /command:clone /url:&quot;%1&quot;" Type="string" />
 					</Component>
+					<Component Id="ProtocolGithub" Guid="$(var.GuidProtocolGithub)" Win64="$(var.Win64YesNo)">
+						<RegistryValue Root="HKLM" Key="Software\Classes\github-windows" Value="URL: Github-Windows Protocol" Type="string" />
+						<RegistryValue Root="HKLM" Key="Software\Classes\github-windows" Name="URL Protocol" Value="" Type="string" />
+						<RegistryValue Root="HKLM" Key="Software\Classes\github-windows\DefaultIcon" Value="[INSTALLDIR]bin\TortoiseGitProc.exe" Type="string" />
+						<RegistryValue Root="HKLM" Key="Software\Classes\github-windows\shell\open\command" Value="&quot;[INSTALLDIR]bin\TortoiseGitProc.exe&quot; /urlhandler:&quot;%1&quot;" Type="string" />
+					</Component>
+					<Component Id="ProtocolSmartgit" Guid="$(var.GuidProtocolSmartgit)" Win64="$(var.Win64YesNo)">
+						<RegistryValue Root="HKLM" Key="Software\Classes\smartgit" Value="URL: Smartgit Protocol" Type="string" />
+						<RegistryValue Root="HKLM" Key="Software\Classes\smartgit" Name="URL Protocol" Value="" Type="string" />
+						<RegistryValue Root="HKLM" Key="Software\Classes\smartgit\DefaultIcon" Value="[INSTALLDIR]bin\TortoiseGitProc.exe" Type="string" />
+						<RegistryValue Root="HKLM" Key="Software\Classes\smartgit\shell\open\command" Value="&quot;[INSTALLDIR]bin\TortoiseGitProc.exe&quot; /urlhandler:&quot;%1&quot;" Type="string" />
+					</Component>
 
 					<Component Id="C__TortoiseGitTools" Guid="$(var.GuidTortoiseGitTools)" Win64="$(var.Win64YesNo)">
             <?if $(var.Platform) = "x86" ?>

--- a/src/TortoiseProc/TortoiseProc.cpp
+++ b/src/TortoiseProc/TortoiseProc.cpp
@@ -266,6 +266,30 @@ BOOL CTortoiseProcApp::InitInstance()
 	if (CRegDWORD(_T("Software\\TortoiseGit\\Debug"), FALSE)==TRUE)
 		AfxMessageBox(AfxGetApp()->m_lpCmdLine, MB_OK | MB_ICONINFORMATION);
 
+	if (parser.HasKey(_T("urlhandler")))
+	{
+		CString url = parser.GetVal(_T("urlhandler"));
+		if (url.Find(_T("github-windows://openRepo/")) == 0)
+		{
+			url = url.Mid(26); // 26 = "github-windows://openRepo/".GetLength()
+			int questioMark = url.Find('?');
+			if (questioMark > 0)
+				url = url.Left(questioMark);
+		}
+		else if (url.Find(_T("smartgit://cloneRepo/")) == 0)
+		{
+			url = url.Mid(21); // 21 = "smartgit://cloneRepo/".GetLength()
+		}
+		else
+		{
+			CMessageBox::Show(NULL, IDS_ERR_INVALIDPATH, IDS_APPNAME, MB_ICONERROR);
+			return FALSE;
+		}
+		CString newCmd;
+		newCmd.Format(_T("/command:clone /url:\"%s\""), url);
+		parser = CCmdLineParser(newCmd);
+	}
+
 	if ( parser.HasKey(_T("path")) && parser.HasKey(_T("pathfile")))
 	{
 		CMessageBox::Show(NULL, IDS_ERR_INVALIDPATH, IDS_APPNAME, MB_ICONERROR);


### PR DESCRIPTION
Do we also want to support "foreign" url handlers (as Git Extensions does)?

Those are not installed by default.
