### PR TITLE
Prevent to add files to list more than once

### DIFF
--- a/src/Git/GitStatusListCtrl.cpp
+++ b/src/Git/GitStatusListCtrl.cpp
@@ -3826,6 +3826,7 @@ int CGitStatusListCtrl::UpdateFileList(git_revnum_t hash,CTGitPathList *list)
 				cmdList += cmd + _T("\n");
 				g_Git.Run(cmd, &cmdout);
 				out.append(cmdout,0);
+				break;
 			}
 		}
 


### PR DESCRIPTION
All added files have been listed, it done there.
Don't go next iteration in that loop.

Signed-off-by: Yue Lin Ho b8732003@student.nsysu.edu.tw
