### PR TITLE
CGitLogListBase: Use one repository instance in ReloadHashMap

### DIFF
--- a/src/Git/Git.cpp
+++ b/src/Git/Git.cpp
@@ -1567,6 +1567,25 @@ int CGit::GetBranchList(STRING_VECTOR &list,int *current,BRANCH_TYPE type)
 	return ret;
 }
 
+int CGit::GetRemoteList(git_repository* repo, STRING_VECTOR &list)
+{
+	ATLASSERT(repo);
+
+	CAutoStrArray remotes;
+	if (git_remote_list(remotes, repo))
+		return -1;
+
+	for (size_t i = 0; i < remotes->count; ++i)
+	{
+		CStringA remote(remotes->strings[i]);
+		list.push_back(CUnicodeUtils::GetUnicode(remote));
+	}
+
+	std::sort(list.begin(), list.end());
+
+	return 0;
+}
+
 int CGit::GetRemoteList(STRING_VECTOR &list)
 {
 	if (this->m_IsUseLibGit2)
@@ -1575,19 +1594,7 @@ int CGit::GetRemoteList(STRING_VECTOR &list)
 		if (!repo)
 			return -1;
 
-		CAutoStrArray remotes;
-		if (git_remote_list(remotes, repo))
-			return -1;
-
-		for (size_t i = 0; i < remotes->count; ++i)
-		{
-			CStringA remote(remotes->strings[i]);
-			list.push_back(CUnicodeUtils::GetUnicode(remote));
-		}
-
-		std::sort(list.begin(), list.end());
-
-		return 0;
+		return GetRemoteList(repo, list);
 	}
 	else
 	{

--- a/src/Git/Git.h
+++ b/src/Git/Git.h
@@ -299,6 +299,7 @@ public:
 	}REF_TYPE;
 
 	int GetRemoteList(STRING_VECTOR &list);
+	static int GetRemoteList(git_repository* repo, STRING_VECTOR &list);
 	int GetBranchList(STRING_VECTOR &list, int *Current,BRANCH_TYPE type=BRANCH_LOCAL);
 	int GetTagList(STRING_VECTOR &list);
 	int GetRemoteTags(const CString& remote, STRING_VECTOR &list);

--- a/src/TortoiseProc/GitLogListBase.cpp
+++ b/src/TortoiseProc/GitLogListBase.cpp
@@ -2976,10 +2976,10 @@ UINT CGitLogListBase::LogThread()
 	return 0;
 }
 
-void CGitLogListBase::FetchRemoteList()
+void CGitLogListBase::FetchRemoteList(git_repository * repo)
 {
 	STRING_VECTOR remoteList;
-	if (!g_Git.GetRemoteList(remoteList))
+	if (!CGit::GetRemoteList(repo, remoteList))
 		m_SingleRemote = remoteList.size() == 1 ? remoteList[0] : _T("");
 	else
 		m_SingleRemote = _T("");

--- a/src/TortoiseProc/RevisionGraph/RevisionGraphWnd.h
+++ b/src/TortoiseProc/RevisionGraph/RevisionGraphWnd.h
@@ -158,11 +158,17 @@ public:
 	void ReloadHashMap()
 	{
 		m_HashMap.clear();
-		if (g_Git.GetMapHashToFriendName(m_HashMap))
-			MessageBox(g_Git.GetGitLastErr(_T("Could not get all refs.")), _T("TortoiseGit"), MB_ICONERROR);
+		CAutoRepository repo(g_Git.GetGitRepository());
+		if (!repo)
+		{
+			MessageBox(CGit::GetLibGit2LastErr(_T("Could not open repository.")), _T("TortoiseGit"), MB_ICONERROR);
+			return;
+		}
+		if (CGit::GetMapHashToFriendName(repo, m_HashMap))
+			MessageBox(CGit::GetLibGit2LastErr(_T("Could not get all refs.")), _T("TortoiseGit"), MB_ICONERROR);
 		m_CurrentBranch=g_Git.GetCurrentBranch();
-		if (g_Git.GetHash(m_HeadHash, _T("HEAD")))
-			MessageBox(g_Git.GetGitLastErr(_T("Could not get HEAD hash.")), _T("TortoiseGit"), MB_ICONERROR);
+		if (CGit::GetHash(repo, m_HeadHash, _T("HEAD")))
+			MessageBox(CGit::GetLibGit2LastErr(_T("Could not get HEAD hash.")), _T("TortoiseGit"), MB_ICONERROR);
 	}
 
 	std::auto_ptr<CFuture<bool>> updateJob;


### PR DESCRIPTION
This ignores m_IsUseLibGit2, however, the libgit2 functions called here, seem to be very stable and we're using them > 1 year.

I'm unsure about this.