### PR TITLE
Fixed issue #2218: Tortoise Git Extra Backslash with SUBST Drive Paths

### DIFF
--- a/src/Changelog.txt
+++ b/src/Changelog.txt
@@ -6,6 +6,7 @@ Released: unreleased
 
 == Bug Fixes ==
  * Fixed issue #2216: Add fails with message: libgit2: "failed to parse 'warn' as boolean"
+ * Fixed issue #2218: Tortoise Git Extra Backslash with SUBST Drive Paths
 
 = Release 1.8.9.0 =
 Released: 2014-06-09

--- a/src/Git/Git.h
+++ b/src/Git/Git.h
@@ -385,6 +385,26 @@ public:
 	int GetUnifiedDiff(const CTGitPath& path, const git_revnum_t& rev1, const git_revnum_t& rev2, CStringA * buffer, bool bMerge, bool bCombine, int diffContext);
 
 	int GitRevert(int parent, const CGitHash &hash);
+
+	CString CombinePath(const CString &path) const
+	{
+		if (path.IsEmpty())
+			return m_CurrentDir;
+		if (m_CurrentDir.IsEmpty())
+			return path;
+		return m_CurrentDir + (m_CurrentDir.Right(1) == _T("\\") ? _T("") : _T("\\")) + path;
+	}
+
+	CString CombinePath(const CTGitPath &path) const
+	{
+		return CombinePath(path.GetWinPath());
+	}
+
+	CString CombinePath(const CTGitPath *path) const
+	{
+		ATLASSERT(path);
+		return CombinePath(path->GetWinPath());
+	}
 };
 extern void GetTempPath(CString &path);
 extern CString GetTempFile();

--- a/src/Git/GitStatusListCtrl.cpp
+++ b/src/Git/GitStatusListCtrl.cpp
@@ -1850,7 +1850,7 @@ void CGitStatusListCtrl::OnContextMenuList(CWnd * pWnd, CPoint point)
 
 			case IDGITLC_EXPLORE:
 				{
-					CString p = g_Git.m_CurrentDir + _T("\\") + filepath->GetWinPathString();
+					CString p = g_Git.CombinePath(filepath);
 					if (PathFileExists(p))
 					{
 						ITEMIDLIST __unaligned * pidl = ILCreateFromPath(p);
@@ -1889,7 +1889,7 @@ void CGitStatusListCtrl::OnContextMenuList(CWnd * pWnd, CPoint point)
 						// delete the temp file: the temp file has the FILE_ATTRIBUTE_TEMPORARY flag set
 						// and copying the real file over it would leave that temp flag.
 						DeleteFile(tempFile.GetWinPath());
-						if (CopyFile(g_Git.m_CurrentDir + _T("\\") + entry2->GetWinPathString(), tempFile.GetWinPath(), FALSE))
+						if (CopyFile(g_Git.CombinePath(entry2), tempFile.GetWinPath(), FALSE))
 						{
 							m_restorepaths[entry2->GetWinPathString()] = tempFile.GetWinPathString();
 							SetItemState(index, INDEXTOOVERLAYMASK(OVL_RESTORE), LVIS_OVERLAYMASK);
@@ -1913,7 +1913,7 @@ void CGitStatusListCtrl::OnContextMenuList(CWnd * pWnd, CPoint point)
 							continue;
 						if (m_restorepaths.find(entry2->GetWinPathString()) == m_restorepaths.end())
 							continue;
-						if (CopyFile(m_restorepaths[entry2->GetWinPathString()], g_Git.m_CurrentDir + _T("\\") + entry2->GetWinPathString(), FALSE))
+						if (CopyFile(m_restorepaths[entry2->GetWinPathString()], g_Git.CombinePath(entry2), FALSE))
 						{
 							m_restorepaths.erase(entry2->GetWinPathString());
 							SetItemState(index, 0, LVIS_OVERLAYMASK);
@@ -2061,7 +2061,7 @@ void CGitStatusListCtrl::OnContextMenuList(CWnd * pWnd, CPoint point)
 			case IDGITLC_LOGSUBMODULE:
 				{
 					CString sCmd;
-					sCmd.Format(_T("/command:log /path:\"%s\""), g_Git.m_CurrentDir + _T("\\") + filepath->GetWinPath());
+					sCmd.Format(_T("/command:log /path:\"%s\""), g_Git.CombinePath(filepath));
 					if (cmd == IDGITLC_LOG && filepath->IsDirectory())
 						sCmd += _T(" /submodule");
 					if (!m_sDisplayedBranch.IsEmpty())
@@ -2074,7 +2074,7 @@ void CGitStatusListCtrl::OnContextMenuList(CWnd * pWnd, CPoint point)
 				{
 					CTGitPath oldName(filepath->GetGitOldPathString());
 					CString sCmd;
-					sCmd.Format(_T("/command:log /path:\"%s\""), g_Git.m_CurrentDir + _T("\\") + oldName.GetWinPath());
+					sCmd.Format(_T("/command:log /path:\"%s\""), g_Git.CombinePath(oldName));
 					if (!m_sDisplayedBranch.IsEmpty())
 						sCmd += _T(" /range:\"") + m_sDisplayedBranch + _T("\"");
 					CAppUtils::RunTortoiseGitProc(sCmd);
@@ -2085,7 +2085,7 @@ void CGitStatusListCtrl::OnContextMenuList(CWnd * pWnd, CPoint point)
 				{
 					if (CAppUtils::ConflictEdit(*filepath, false, m_bIsRevertTheirMy, GetLogicalParent() ? GetLogicalParent()->GetSafeHwnd() : nullptr))
 					{
-						CString conflictedFile = g_Git.m_CurrentDir + _T("\\") + filepath->GetWinPathString();
+						CString conflictedFile = g_Git.CombinePath(filepath);
 						if (!PathFileExists(conflictedFile) && NULL != GetLogicalParent() && NULL != GetLogicalParent()->GetSafeHwnd())
 							GetLogicalParent()->SendMessage(GITSLNM_NEEDSREFRESH);
 					}
@@ -2646,7 +2646,7 @@ void CGitStatusListCtrl::OnNMDblclk(NMHDR *pNMHDR, LRESULT *pResult)
 	{
 		if (CAppUtils::ConflictEdit(*file, false, m_bIsRevertTheirMy, GetLogicalParent() ? GetLogicalParent()->GetSafeHwnd() : nullptr))
 		{
-			CString conflictedFile = g_Git.m_CurrentDir + _T("\\") + file->GetWinPathString();
+			CString conflictedFile = g_Git.CombinePath(file);
 			if (!PathFileExists(conflictedFile) && NULL != GetLogicalParent() && NULL != GetLogicalParent()->GetSafeHwnd())
 				GetLogicalParent()->SendMessage(GITSLNM_NEEDSREFRESH);
 		}
@@ -4302,7 +4302,7 @@ void CGitStatusListCtrl::FilesExport()
 		CString filename = exportDir + _T("\\") + fd->GetWinPathString();
 		if (m_CurrentVersion == GIT_REV_ZERO)
 		{
-			if (!CopyFile(g_Git.m_CurrentDir + _T("\\") + fd->GetWinPath(), filename, false))
+			if (!CopyFile(g_Git.CombinePath(fd), filename, false))
 			{
 				MessageBox(CFormatMessageWrapper(), _T("TortoiseGit"), MB_OK | MB_ICONERROR);
 				return;
@@ -4330,7 +4330,7 @@ void CGitStatusListCtrl::FileSaveAs(CTGitPath *path)
 					OFN_HIDEREADONLY | OFN_OVERWRITEPROMPT,
 					NULL);
 	CString currentpath;
-	currentpath = g_Git.m_CurrentDir + _T("\\") + path->GetContainingDirectory().GetWinPath();
+	currentpath = g_Git.CombinePath(path->GetContainingDirectory());
 
 	dlg.m_ofn.lpstrInitialDir=currentpath.GetBuffer();
 
@@ -4421,7 +4421,7 @@ void CGitStatusListCtrl::OpenFile(CTGitPath*filepath,int mode)
 	CString file;
 	if(this->m_CurrentVersion.IsEmpty() || m_CurrentVersion == GIT_REV_ZERO)
 	{
-		file = g_Git.m_CurrentDir + _T("\\") + filepath->GetWinPath();
+		file = g_Git.CombinePath(filepath);
 	}
 	else
 	{

--- a/src/TortoiseProc/AddDlg.cpp
+++ b/src/TortoiseProc/AddDlg.cpp
@@ -75,7 +75,7 @@ BOOL CAddDlg::OnInitDialog()
 
 	CString sWindowTitle;
 	GetWindowText(sWindowTitle);
-	CAppUtils::SetWindowTitle(m_hWnd, (g_Git.m_CurrentDir + _T("\\") + m_pathList.GetCommonRoot().GetUIPathString()).TrimRight('\\'), sWindowTitle);
+	CAppUtils::SetWindowTitle(m_hWnd, g_Git.CombinePath(m_pathList.GetCommonRoot().GetUIPathString()), sWindowTitle);
 
 	AdjustControlSize(IDC_SELECTALL);
 	AdjustControlSize(IDC_INCLUDE_IGNORED);

--- a/src/TortoiseProc/AppUtils.cpp
+++ b/src/TortoiseProc/AppUtils.cpp
@@ -1009,7 +1009,7 @@ bool CAppUtils::Export(CString *BashHash, const CTGitPath *orgPath)
 	if (orgPath)
 	{
 		if (PathIsRelative(orgPath->GetWinPath()))
-			dlg.m_orgPath = g_Git.m_CurrentDir + _T("\\") + orgPath->GetWinPathString();
+			dlg.m_orgPath = g_Git.CombinePath(orgPath);
 		else
 			dlg.m_orgPath = *orgPath;
 	}
@@ -1333,7 +1333,7 @@ bool CAppUtils::IgnoreFile(CTGitPathList &path,bool IsMask)
 			{
 				if (ignoreDlg.m_IgnoreFile == 1)
 				{
-					ignorefile = g_Git.m_CurrentDir + _T("\\") + path[i].GetContainingDirectory().GetWinPathString() + _T("\\.gitignore");
+					ignorefile = g_Git.CombinePath(path[i].GetContainingDirectory()) + _T("\\.gitignore");
 					if (!OpenIgnoreFile(file, ignorefile))
 						return false;
 				}

--- a/src/TortoiseProc/ChangedDlg.cpp
+++ b/src/TortoiseProc/ChangedDlg.cpp
@@ -241,9 +241,9 @@ void CChangedDlg::SetDlgTitle()
 	else
 	{
 		if (m_pathList.GetCount() == 1)
-			CAppUtils::SetWindowTitle(m_hWnd, (g_Git.m_CurrentDir + _T("\\") + m_pathList[0].GetUIPathString()).TrimRight('\\'), m_sTitle);
+			CAppUtils::SetWindowTitle(m_hWnd, g_Git.CombinePath(m_pathList[0].GetUIPathString()), m_sTitle);
 		else
-			CAppUtils::SetWindowTitle(m_hWnd, g_Git.m_CurrentDir + _T("\\") + m_FileListCtrl.GetCommonDirectory(false), m_sTitle);
+			CAppUtils::SetWindowTitle(m_hWnd, g_Git.CombinePath(m_FileListCtrl.GetCommonDirectory(false)), m_sTitle);
 	}
 }
 
@@ -383,7 +383,7 @@ void CChangedDlg::OnBnClickedCommit()
 	if (bSingleFile)
 		cmd += m_pathList[0].GetWinPathString();
 	else
-		cmd += g_Git.m_CurrentDir + _T("\\") + m_pathList.GetCommonRoot().GetDirectory().GetWinPath();
+		cmd += g_Git.CombinePath(m_pathList.GetCommonRoot().GetDirectory());
 	cmd += _T("\"");
 	CAppUtils::RunTortoiseGitProc(cmd);
 }

--- a/src/TortoiseProc/Commands/SubmoduleCommand.cpp
+++ b/src/TortoiseProc/Commands/SubmoduleCommand.cpp
@@ -71,7 +71,7 @@ bool SubmoduleAddCommand::Execute()
 				SetCurrentDirectory(g_Git.m_CurrentDir);
 				CGit subgit;
 				dlg.m_strPath.Replace(_T('/'), _T('\\'));
-				subgit.m_CurrentDir = PathIsRelative(dlg.m_strPath) ? g_Git.m_CurrentDir + _T("\\") + dlg.m_strPath : dlg.m_strPath;
+				subgit.m_CurrentDir = PathIsRelative(dlg.m_strPath) ? g_Git.CombinePath(dlg.m_strPath) : dlg.m_strPath;
 
 				if (subgit.SetConfigValue(_T("remote.origin.puttykeyfile"), dlg.m_strPuttyKeyFile, CONFIG_LOCAL))
 				{

--- a/src/TortoiseProc/CommitDlg.cpp
+++ b/src/TortoiseProc/CommitDlg.cpp
@@ -573,7 +573,7 @@ void CCommitDlg::OnOK()
 		if (entry->m_Action & CTGitPath::LOGACTIONS_UNVER)
 		{
 			CGit subgit;
-			subgit.m_CurrentDir = g_Git.m_CurrentDir + _T("\\") + entry->GetWinPathString();
+			subgit.m_CurrentDir = g_Git.CombinePath(entry);
 			CString subcmdout;
 			subgit.Run(_T("git.exe status --porcelain"), &subcmdout, CP_UTF8);
 			dirty = !subcmdout.IsEmpty();
@@ -1300,9 +1300,9 @@ void CCommitDlg::SetDlgTitle()
 	else
 	{
 		if (m_pathList.GetCount() == 1)
-			CAppUtils::SetWindowTitle(m_hWnd, (g_Git.m_CurrentDir + _T("\\") + m_pathList[0].GetUIPathString()).TrimRight('\\'), m_sTitle);
+			CAppUtils::SetWindowTitle(m_hWnd, g_Git.CombinePath(m_pathList[0].GetUIPathString()), m_sTitle);
 		else
-			CAppUtils::SetWindowTitle(m_hWnd, g_Git.m_CurrentDir + _T("\\") + m_ListCtrl.GetCommonDirectory(false), m_sTitle);
+			CAppUtils::SetWindowTitle(m_hWnd, g_Git.CombinePath(m_ListCtrl.GetCommonDirectory(false)), m_sTitle);
 	}
 }
 
@@ -2541,7 +2541,7 @@ void CCommitDlg::RestoreFiles(bool doNotAsk)
 	if (!m_ListCtrl.m_restorepaths.empty() && (doNotAsk || CMessageBox::Show(m_hWnd, IDS_PROC_COMMIT_RESTOREFILES, IDS_APPNAME, 2, IDI_QUESTION, IDS_PROC_COMMIT_RESTOREFILES_RESTORE, IDS_PROC_COMMIT_RESTOREFILES_KEEP) == 1))
 	{
 		for (std::map<CString, CString>::iterator it = m_ListCtrl.m_restorepaths.begin(); it != m_ListCtrl.m_restorepaths.end(); ++it)
-			CopyFile(it->second, g_Git.m_CurrentDir + _T("\\") + it->first, FALSE);
+			CopyFile(it->second, g_Git.CombinePath(it->first), FALSE);
 		m_ListCtrl.m_restorepaths.clear();
 	}
 }

--- a/src/TortoiseProc/DeleteConflictDlg.cpp
+++ b/src/TortoiseProc/DeleteConflictDlg.cpp
@@ -107,6 +107,6 @@ void CDeleteConflictDlg::OnBnClickedModify()
 void CDeleteConflictDlg::ShowLog(CString hash)
 {
 	CString sCmd;
-	sCmd.Format(_T("/command:log /path:\"%s\" /endrev:%s"), g_Git.m_CurrentDir + _T("\\") + m_File, hash);
+	sCmd.Format(_T("/command:log /path:\"%s\" /endrev:%s"), g_Git.CombinePath(m_File), hash);
 	CAppUtils::RunTortoiseGitProc(sCmd, false, false);
 }

--- a/src/TortoiseProc/FileDiffDlg.cpp
+++ b/src/TortoiseProc/FileDiffDlg.cpp
@@ -198,7 +198,7 @@ BOOL CFileDiffDlg::OnInitDialog()
 	GetWindowText(sWindowTitle);
 	CString pathText = g_Git.m_CurrentDir;
 	if (!m_path1.IsEmpty())
-		pathText = g_Git.m_CurrentDir + _T("\\") + m_path1.GetWinPathString();
+		pathText = g_Git.CombinePath(m_path1);
 	CAppUtils::SetWindowTitle(m_hWnd, pathText, sWindowTitle);
 
 	this->m_ctrRev1Edit.Init();
@@ -745,7 +745,7 @@ void CFileDiffDlg::OnContextMenu(CWnd* pWnd, CPoint point)
 						CString filename = m_strExportDir + _T("\\") + fd->GetWinPathString();
 						if(m_rev1.m_CommitHash.ToString() == GIT_REV_ZERO)
 						{
-							if(!CopyFile(g_Git.m_CurrentDir + _T("\\") + fd->GetWinPath(), filename, false))
+							if(!CopyFile(g_Git.CombinePath(fd), filename, false))
 							{
 								MessageBox(CFormatMessageWrapper(), _T("TortoiseGit"), MB_OK | MB_ICONERROR);
 								return;

--- a/src/TortoiseProc/GitDiff.cpp
+++ b/src/TortoiseProc/GitDiff.cpp
@@ -162,14 +162,14 @@ int CGitDiff::DiffNull(const CTGitPath *pPath, git_revnum_t rev1, bool bIsAdd, i
 		CAppUtils::StartExtDiff(tempfile,file1,
 							pPath->GetGitPathString(),
 							pPath->GetGitPathString() + _T(":") + rev1.Left(g_Git.GetShortHASHLength()),
-							g_Git.m_CurrentDir + _T("\\") + pPath->GetWinPathString(), g_Git.m_CurrentDir + _T("\\") + pPath->GetWinPathString(),
+							g_Git.CombinePath(pPath), g_Git.CombinePath(pPath),
 							git_revnum_t(GIT_REV_ZERO), rev1
 							, flags, jumpToLine);
 	else
 		CAppUtils::StartExtDiff(file1,tempfile,
 							pPath->GetGitPathString() + _T(":") + rev1.Left(g_Git.GetShortHASHLength()),
 							pPath->GetGitPathString(),
-							g_Git.m_CurrentDir + _T("\\") + pPath->GetWinPathString(), g_Git.m_CurrentDir + _T("\\") + pPath->GetWinPathString(),
+							g_Git.CombinePath(pPath), g_Git.CombinePath(pPath),
 							rev1, git_revnum_t(GIT_REV_ZERO)
 							, flags, jumpToLine);
 
@@ -427,7 +427,7 @@ int CGitDiff::Diff(const CTGitPath * pPath, const CTGitPath * pPath2, git_revnum
 	}
 	else
 	{
-		file1=g_Git.m_CurrentDir+_T("\\")+pPath->GetWinPathString();
+		file1 = g_Git.CombinePath(pPath);
 		title1.Format( IDS_DIFF_WCNAME, pPath->GetFileOrDirectoryName() );
 		if (!PathFileExists(file1))
 		{
@@ -490,8 +490,8 @@ int CGitDiff::Diff(const CTGitPath * pPath, const CTGitPath * pPath2, git_revnum
 		CAppUtils::StartExtDiff(file2,file1,
 								title2,
 								title1,
-								g_Git.m_CurrentDir + _T("\\") + pPath2->GetWinPathString(),
-								g_Git.m_CurrentDir + _T("\\") + pPath->GetWinPathString(),
+								g_Git.CombinePath(pPath2),
+								g_Git.CombinePath(pPath),
 								rev2,
 								rev1,
 								flags, jumpToLine);

--- a/src/TortoiseProc/GitProgressList.cpp
+++ b/src/TortoiseProc/GitProgressList.cpp
@@ -1710,7 +1710,7 @@ void CGitProgressList::OnSize(UINT nType, int cx, int cy)
 bool CGitProgressList::CmdAdd(CString& sWindowTitle, bool& localoperation)
 {
 	localoperation = true;
-	SetWindowTitle(IDS_PROGRS_TITLE_ADD, g_Git.m_CurrentDir + _T("\\") + m_targetPathList.GetCommonRoot().GetUIPathString(), sWindowTitle);
+	SetWindowTitle(IDS_PROGRS_TITLE_ADD, g_Git.CombinePath(m_targetPathList.GetCommonRoot().GetUIPathString()), sWindowTitle);
 	SetBackgroundImage(IDI_ADD_BKG);
 	ReportCmd(CString(MAKEINTRESOURCE(IDS_PROGRS_CMD_ADD)));
 
@@ -1866,7 +1866,7 @@ bool CGitProgressList::CmdResolve(CString& sWindowTitle, bool& localoperation)
 
 	localoperation = true;
 	ASSERT(m_targetPathList.GetCount() == 1);
-	SetWindowTitle(IDS_PROGRS_TITLE_RESOLVE, g_Git.m_CurrentDir + _T("\\") + m_targetPathList.GetCommonRoot().GetUIPathString(), sWindowTitle);
+	SetWindowTitle(IDS_PROGRS_TITLE_RESOLVE, g_Git.CombinePath(m_targetPathList.GetCommonRoot().GetUIPathString()), sWindowTitle);
 	SetBackgroundImage(IDI_RESOLVE_BKG);
 	// check if the file may still have conflict markers in it.
 	//BOOL bMarkers = FALSE;
@@ -1945,7 +1945,7 @@ bool CGitProgressList::CmdRevert(CString& sWindowTitle, bool& localoperation)
 {
 
 	localoperation = true;
-	SetWindowTitle(IDS_PROGRS_TITLE_REVERT, g_Git.m_CurrentDir + _T("\\") + m_targetPathList.GetCommonRoot().GetUIPathString(), sWindowTitle);
+	SetWindowTitle(IDS_PROGRS_TITLE_REVERT, g_Git.CombinePath(m_targetPathList.GetCommonRoot().GetUIPathString()), sWindowTitle);
 	SetBackgroundImage(IDI_REVERT_BKG);
 
 	m_itemCountTotal = 2 * m_selectedPaths.GetCount();
@@ -1954,7 +1954,7 @@ bool CGitProgressList::CmdRevert(CString& sWindowTitle, bool& localoperation)
 	{
 		CTGitPath path;
 		int action;
-		path.SetFromWin(g_Git.m_CurrentDir + _T("\\") + m_selectedPaths[m_itemCount].GetWinPath());
+		path.SetFromWin(g_Git.CombinePath(m_selectedPaths[m_itemCount]));
 		action = m_selectedPaths[m_itemCount].m_Action;
 		/* rename file can't delete because it needs original file*/
 		if((!(action & CTGitPath::LOGACTIONS_ADDED)) &&
@@ -2082,7 +2082,7 @@ error:
 bool CGitProgressList::CmdSendMail(CString& sWindowTitle, bool& /*localoperation*/)
 {
 	ASSERT(m_SendMail);
-	SetWindowTitle(IDS_PROGRS_TITLE_SENDMAIL, g_Git.m_CurrentDir + _T("\\") + m_targetPathList.GetCommonRoot().GetUIPathString(), sWindowTitle);
+	SetWindowTitle(IDS_PROGRS_TITLE_SENDMAIL, g_Git.CombinePath(m_targetPathList.GetCommonRoot().GetUIPathString()), sWindowTitle);
 	//SetBackgroundImage(IDI_ADD_BKG);
 	ReportCmd(CString(MAKEINTRESOURCE(IDS_PROGRS_CMD_SENDMAIL)));
 
@@ -2309,7 +2309,7 @@ CString CGitProgressList::GetPathFromColumnText(const CString& sColumnText)
 	if (sPath.Find(':')<0)
 	{
 		// the path is not absolute: add the common root of all paths to it
-		sPath = g_Git.m_CurrentDir + _T("\\") + sColumnText;
+		sPath = g_Git.CombinePath(sColumnText);
 	}
 	return sPath;
 }

--- a/src/TortoiseProc/LogDlg.cpp
+++ b/src/TortoiseProc/LogDlg.cpp
@@ -1374,7 +1374,7 @@ void CLogDlg::DoDiffFromLog(INT_PTR selIndex, GitRev* rev1, GitRev* rev2, bool /
 
 	CAppUtils::DiffFlags flags;
 	CAppUtils::StartExtDiff(file1,file2,_T("A"),_T("B"),
-													g_Git.m_CurrentDir + _T("\\") + path.GetWinPathString(), g_Git.m_CurrentDir + _T("\\") + path.GetWinPathString(),
+													g_Git.CombinePath(path), g_Git.CombinePath(path),
 													rev1->m_CommitHash.ToString(), rev2->m_CommitHash.ToString(),
 													flags);
 

--- a/src/TortoiseProc/RepositoryBrowser.cpp
+++ b/src/TortoiseProc/RepositoryBrowser.cpp
@@ -799,7 +799,7 @@ void CRepositoryBrowser::ShowContextMenu(CPoint point, TShadowFilesTreeList &sel
 		break;
 	case eCmd_Blame:
 		{
-			CAppUtils::LaunchTortoiseBlame(g_Git.m_CurrentDir + _T("\\") + selectedLeafs.at(0)->GetFullName(), m_sRevision);
+			CAppUtils::LaunchTortoiseBlame(g_Git.CombinePath(selectedLeafs.at(0)->GetFullName()), m_sRevision);
 		}
 		break;
 	case eCmd_Open:
@@ -1161,7 +1161,7 @@ void CRepositoryBrowser::FileSaveAs(const CString path)
 	filename.Format(_T("%s-%s%s"), gitPath.GetBaseFilename(), hash.ToString().Left(g_Git.GetShortHASHLength()), gitPath.GetFileExtension());
 	CFileDialog dlg(FALSE, NULL, filename, OFN_HIDEREADONLY | OFN_OVERWRITEPROMPT, NULL);
 
-	CString currentpath(g_Git.m_CurrentDir + _T("\\") + gitPath.GetContainingDirectory().GetWinPath());
+	CString currentpath(g_Git.CombinePath(gitPath.GetContainingDirectory()));
 	dlg.m_ofn.lpstrInitialDir = currentpath.GetBuffer();
 
 	CString cmd, out;
@@ -1217,7 +1217,7 @@ void CRepositoryBrowser::OpenFile(const CString path, eOpenType mode, bool isSub
 			}
 
 			CString cmd;
-			cmd.Format(_T("/command:repobrowser /path:\"%s\" /rev:%s"), g_Git.m_CurrentDir + _T("\\") + path, itemHash.ToString());
+			cmd.Format(_T("/command:repobrowser /path:\"%s\" /rev:%s"), g_Git.CombinePath(path), itemHash.ToString());
 			CAppUtils::RunTortoiseGitProc(cmd);
 			return;
 		}

--- a/src/TortoiseProc/RevertDlg.cpp
+++ b/src/TortoiseProc/RevertDlg.cpp
@@ -74,7 +74,7 @@ BOOL CRevertDlg::OnInitDialog()
 	CString sWindowTitle;
 	GetWindowText(sWindowTitle);
 	if (m_pathList.GetCount() == 1)
-		CAppUtils::SetWindowTitle(m_hWnd, (g_Git.m_CurrentDir + _T("\\") + m_pathList[0].GetUIPathString()).TrimRight('\\'), sWindowTitle);
+		CAppUtils::SetWindowTitle(m_hWnd, g_Git.CombinePath(m_pathList[0].GetUIPathString()), sWindowTitle);
 	else
 		CAppUtils::SetWindowTitle(m_hWnd, m_pathList.GetCommonRoot().GetUIPathString(), sWindowTitle);
 

--- a/src/TortoiseProc/SubmoduleAddDlg.cpp
+++ b/src/TortoiseProc/SubmoduleAddDlg.cpp
@@ -97,7 +97,7 @@ BOOL CSubmoduleAddDlg::OnInitDialog()
 
 	CString sWindowTitle;
 	GetWindowText(sWindowTitle);
-	CAppUtils::SetWindowTitle(m_hWnd, (g_Git.m_CurrentDir + _T("\\") + m_strPath).TrimRight('\\'), sWindowTitle);
+	CAppUtils::SetWindowTitle(m_hWnd, g_Git.CombinePath(m_strPath).TrimRight('\\'), sWindowTitle);
 
 	m_Repository.SetURLHistory(true);
 	m_Repository.SetCaseSensitive(TRUE);

--- a/src/TortoiseProc/SubmoduleDiffDlg.cpp
+++ b/src/TortoiseProc/SubmoduleDiffDlg.cpp
@@ -224,7 +224,7 @@ void CSubmoduleDiffDlg::SetDiff(CString path, bool toIsWorkingCopy, CString from
 void CSubmoduleDiffDlg::ShowLog(CString hash)
 {
 	CString sCmd;
-	sCmd.Format(_T("/command:log /path:\"%s\" /endrev:%s"), g_Git.m_CurrentDir + _T("\\") + m_sPath, hash);
+	sCmd.Format(_T("/command:log /path:\"%s\" /endrev:%s"), g_Git.CombinePath(m_sPath), hash);
 	CAppUtils::RunTortoiseGitProc(sCmd, false, false);
 }
 
@@ -241,7 +241,7 @@ void CSubmoduleDiffDlg::OnBnClickedLog2()
 void CSubmoduleDiffDlg::OnBnClickedShowDiff()
 {
 	CString sCmd;
-	sCmd.Format(_T("/command:showcompare /path:\"%s\" /revision1:%s /revision2:%s"), g_Git.m_CurrentDir + _T("\\") + m_sPath, m_sFromHash, ((m_bDirty && m_nChangeType == Unknown) || m_ctrlShowDiffBtn.GetCurrentEntry() == 1) ? GIT_REV_ZERO : m_sToHash);
+	sCmd.Format(_T("/command:showcompare /path:\"%s\" /revision1:%s /revision2:%s"), g_Git.CombinePath(m_sPath), m_sFromHash, ((m_bDirty && m_nChangeType == Unknown) || m_ctrlShowDiffBtn.GetCurrentEntry() == 1) ? GIT_REV_ZERO : m_sToHash);
 	CAppUtils::RunTortoiseGitProc(sCmd, false, false);
 }
 


### PR DESCRIPTION
https://tortoisegit.org/issue/2218

Use common function to combine `g_Git.m_CurrentDir` and file
