### PR TITLE
WIP: Add more hooks

### DIFF
--- a/doc/source/en/TortoiseGit/tgit_dug/dug_settings_hooks.xml
+++ b/doc/source/en/TortoiseGit/tgit_dug/dug_settings_hooks.xml
@@ -140,7 +140,6 @@
 				<term>Pre-push</term>
 				<listitem condition="pot">
 					<para>
-						<literal>PATH</literal>
 						<literal>ERROR</literal>
 						<literal>CWD</literal>
 					</para>
@@ -150,7 +149,24 @@
 				<term>Post-push</term>
 				<listitem condition="pot">
 					<para>
-						<literal>PATH</literal>
+						<literal>ERROR</literal>
+						<literal>CWD</literal>
+					</para>
+				</listitem>
+			</varlistentry>
+			<varlistentry>
+				<term>Pre-pull</term>
+				<listitem condition="pot">
+					<para>
+						<literal>ERROR</literal>
+						<literal>CWD</literal>
+					</para>
+				</listitem>
+			</varlistentry>
+			<varlistentry>
+				<term>Post-pull/term>
+				<listitem condition="pot">
+					<para>
 						<literal>ERROR</literal>
 						<literal>CWD</literal>
 					</para>

--- a/src/Resources/TortoiseProcENG.rc
+++ b/src/Resources/TortoiseProcENG.rc
@@ -4711,6 +4711,12 @@ BEGIN
     IDS_MERGEBUTTON         "&Merge"
     IDS_REBASEBUTTON        "&Rebase"
     IDS_RESTORE_FROM_INDEX  "R&estore this file from index"
+    IDS_HOOKTYPE_PREPULL    "Pre-pull hook"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_HOOKTYPE_POSTPULL   "Post-pull hook"
 END
 
 #endif    // English (U.S.) resources

--- a/src/TortoiseProc/AppUtils.cpp
+++ b/src/TortoiseProc/AppUtils.cpp
@@ -2396,6 +2396,19 @@ bool CAppUtils::Pull(bool showPush, bool showStashPop)
 							dlg.m_RemoteBranchName,
 							TRUE); // Rebase after fetching
 
+		CString error;
+		DWORD exitcode = 0xFFFFFFFF;
+		if (CHooks::Instance().PrePull(g_Git.m_CurrentDir, exitcode, error))
+		{
+			if (exitcode)
+			{
+				CString temp;
+				temp.Format(IDS_ERR_HOOKFAILED, (LPCTSTR)error);
+				MessageBox(nullptr, temp, _T("TortoiseGit"), MB_OK | MB_ICONERROR);
+				return false;
+			}
+		}
+
 		CString url = dlg.m_RemoteURL;
 
 		if (dlg.m_bAutoLoad)
@@ -2502,6 +2515,19 @@ bool CAppUtils::Pull(bool showPush, bool showStashPop)
 		};
 
 		INT_PTR ret = progress.DoModal();
+
+		error.Empty();
+		exitcode = 0xFFFFFFFF;
+		if (CHooks::Instance().PostPull(g_Git.m_CurrentDir, exitcode, error))
+		{
+			if (exitcode)
+			{
+				CString temp;
+				temp.Format(IDS_ERR_HOOKFAILED, (LPCTSTR)error);
+				MessageBox(nullptr, temp, _T("TortoiseGit"), MB_OK | MB_ICONERROR);
+				return false;
+			}
+		}
 
 		if (ret == IDOK && progress.m_GitStatus == 1 && progress.m_LogText.Find(_T("CONFLICT")) >= 0 && CMessageBox::Show(NULL, IDS_SEECHANGES, IDS_APPNAME, MB_YESNO | MB_ICONINFORMATION) == IDYES)
 		{

--- a/src/TortoiseProc/Settings/SetHooksAdv.cpp
+++ b/src/TortoiseProc/Settings/SetHooksAdv.cpp
@@ -74,6 +74,10 @@ BOOL CSetHooksAdv::OnInitDialog()
 	m_cHookTypeCombo.SetItemData(index, pre_push_hook);
 	index = m_cHookTypeCombo.AddString(CString(MAKEINTRESOURCE(IDS_HOOKTYPE_POSTPUSH)));
 	m_cHookTypeCombo.SetItemData(index, post_push_hook);
+	index = m_cHookTypeCombo.AddString(CString(MAKEINTRESOURCE(IDS_HOOKTYPE_PREPULL)));
+	m_cHookTypeCombo.SetItemData(index, pre_pull_hook);
+	index = m_cHookTypeCombo.AddString(CString(MAKEINTRESOURCE(IDS_HOOKTYPE_POSTPULL)));
+	m_cHookTypeCombo.SetItemData(index, post_pull_hook);
 
 	// preselect the right hook type in the combobox
 	for (int i=0; i<m_cHookTypeCombo.GetCount(); ++i)

--- a/src/TortoiseProc/SyncDlg.cpp
+++ b/src/TortoiseProc/SyncDlg.cpp
@@ -188,6 +188,19 @@ void CSyncDlg::OnBnClickedButtonPull()
 		CString remotebranch;
 		remotebranch = m_strRemoteBranch;
 
+		CString error;
+		DWORD exitcode = 0xFFFFFFFF;
+		if (CHooks::Instance().PrePull(g_Git.m_CurrentDir, exitcode, error))
+		{
+			if (exitcode)
+			{
+				CString temp;
+				temp.Format(IDS_ERR_HOOKFAILED, (LPCTSTR)error);
+				MessageBox(temp, _T("TortoiseGit"), MB_OK | MB_ICONERROR);
+				return;
+			}
+		}
+
 		if(!IsURL())
 		{
 			CString pullRemote, pullBranch;
@@ -347,6 +360,19 @@ void CSyncDlg::PullComplete()
 	CGitHash newhash;
 	if (g_Git.GetHash(newhash, _T("HEAD")))
 		MessageBox(g_Git.GetGitLastErr(_T("Could not get HEAD hash after pulling.")), _T("TortoiseGit"), MB_ICONERROR);
+
+	CString error;
+	DWORD exitcode = 0xFFFFFFFF;
+	if (CHooks::Instance().PostPull(g_Git.m_CurrentDir, exitcode, error))
+	{
+		if (exitcode)
+		{
+			CString temp;
+			temp.Format(IDS_ERR_HOOKFAILED, (LPCTSTR)error);
+			MessageBox(temp, _T("TortoiseGit"), MB_OK | MB_ICONERROR);
+			return;
+		}
+	}
 
 	if( this ->m_GitCmdStatus )
 	{

--- a/src/TortoiseProc/resource.h
+++ b/src/TortoiseProc/resource.h
@@ -1226,9 +1226,11 @@
 #define IDC_REP_BROWSE                  1583
 #define IDC_SEND_ADDRESS                1583
 #define IDC_UUIDLABEL64                 1583
+#define IDS_HOOKTYPE_PREPULL            1583
 #define IDC_BUTTON_PATH_BROWSE          1584
 #define IDC_SMTP_SERVER                 1584
 #define IDC_UUID64                      1584
+#define IDS_HOOKTYPE_POSTPULL           1584
 #define IDC_GROUP_SUBMODULE             1585
 #define IDC_SMTP_AUTH                   1585
 #define IDC_PARAMS                      1585

--- a/src/Utils/Hooks.cpp
+++ b/src/Utils/Hooks.cpp
@@ -174,6 +174,10 @@ CString CHooks::GetHookTypeString(hooktype t)
 		return _T("pre_push_hook");
 	case post_push_hook:
 		return _T("post_push_hook");
+	case pre_pull_hook:
+		return _T("pre_pull_hook");
+	case post_pull_hook:
+		return _T("post_pull_hook");
 	}
 	return _T("");
 }
@@ -190,6 +194,10 @@ hooktype CHooks::GetHookType(const CString& s)
 		return pre_push_hook;
 	if (s.Compare(_T("post_push_hook"))==0)
 		return post_push_hook;
+	if (s.Compare(_T("pre_pull_hook")) == 0)
+		return pre_pull_hook;
+	if (s.Compare(_T("post_pull_hook")) == 0)
+		return post_pull_hook;
 
 	return unknown_hook;
 }
@@ -283,7 +291,6 @@ bool CHooks::PrePush(const CString& workingTree, DWORD& exitcode, CString& error
 	if (it == end())
 		return false;
 	CString sCmd = it->second.commandline;
-	AddPathParam(sCmd, CTGitPathList(workingTree));
 	AddErrorParam(sCmd, error);
 	AddCWDParam(sCmd, workingTree);
 	exitcode = RunScript(sCmd, workingTree, error, it->second.bWait, it->second.bShow);
@@ -296,7 +303,30 @@ bool CHooks::PostPush(const CString& workingTree, DWORD& exitcode, CString& erro
 	if (it == end())
 		return false;
 	CString sCmd = it->second.commandline;
-	AddPathParam(sCmd, CTGitPathList(workingTree));
+	AddErrorParam(sCmd, error);
+	AddCWDParam(sCmd, workingTree);
+	exitcode = RunScript(sCmd, workingTree, error, it->second.bWait, it->second.bShow);
+	return true;
+}
+
+bool CHooks::PrePull(const CString& workingTree, DWORD& exitcode, CString& error)
+{
+	auto it = FindItem(pre_pull_hook, workingTree);
+	if (it == end())
+		return false;
+	CString sCmd = it->second.commandline;
+	AddErrorParam(sCmd, error);
+	AddCWDParam(sCmd, workingTree);
+	exitcode = RunScript(sCmd, workingTree, error, it->second.bWait, it->second.bShow);
+	return true;
+}
+
+bool CHooks::PostPull(const CString& workingTree, DWORD& exitcode, CString& error)
+{
+	auto it = FindItem(post_pull_hook, workingTree);
+	if (it == end())
+		return false;
+	CString sCmd = it->second.commandline;
 	AddErrorParam(sCmd, error);
 	AddCWDParam(sCmd, workingTree);
 	exitcode = RunScript(sCmd, workingTree, error, it->second.bWait, it->second.bShow);

--- a/src/Utils/Hooks.h
+++ b/src/Utils/Hooks.h
@@ -37,6 +37,8 @@ typedef enum hooktype
 	issue_tracker_hook,
 	pre_push_hook,
 	post_push_hook,
+	pre_pull_hook,
+	post_pull_hook,
 } hooktype;
 
 /**
@@ -171,6 +173,9 @@ public:
 
 	bool	PrePush(const CString& workingTree, DWORD& exitcode, CString& error);
 	bool	PostPush(const CString& workingTree, DWORD& exitcode, CString& error);
+
+	bool	PrePull(const CString& workingTree, DWORD& exitcode, CString& error);
+	bool	PostPull(const CString& workingTree, DWORD& exitcode, CString& error);
 
 	bool	IsHookPresent(hooktype t, const CString& workingTree) const;
 


### PR DESCRIPTION
This PR extends the hooks in TortoiseGit. I.e. it adds pre, post commit and pre, post pull hooks. Also it changes the behavior of pre and post push to be the same as the already mentioned (i.e., pre push runs immediately before the push starts instead of when the push dialog is opened - in syncdlg it already was correct and post push also runs in case of failure). We differ to TSVN in one case as I'd like to allow the pre commit hook to be able to modify the commit message (for https://code.google.com/p/tortoisegit/issues/detail?id=1605).

Do we also need any other hooks (cf. https://code.google.com/p/tortoisegit/issues/detail?id=1530)? General opinions?