### PR TITLE
Use .gitattributes to prevent pot header EOL issue

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Languages/TortoisePotHeader.txt -lf


### PR DESCRIPTION
e.g.
Mixed EOL introduced in commit ed8c6f5c45733723b1af3d6645cb38412e963151
and it is fixed in commit 595488f712230a6921e7a48e9b338d4c30d68069

_Note_ Re-checkout TortoisePotHeader.txt is needed.

Signed-off-by: Yue Lin Ho b8732003@student.nsysu.edu.tw
