### PR TITLE
Warn user HEAD detached after rebase done

### DIFF
--- a/src/TortoiseProc/AppUtils.cpp
+++ b/src/TortoiseProc/AppUtils.cpp
@@ -1180,7 +1180,7 @@ bool CAppUtils::Export(const CString* BashHash, const CTGitPath* orgPath)
 	return false;
 }
 
-int CAppUtils::CheckHeadDetach()
+int CAppUtils::CheckHeadDetach(const CString& defaultBranchName/*L""*/)
 {
 	CString output;
 	if (CGit::GetCurrentBranchFromFile(g_Git.m_CurrentDir, output))
@@ -1188,7 +1188,7 @@ int CAppUtils::CheckHeadDetach()
 		int retval = CMessageBox::Show(NULL, IDS_PROC_COMMIT_DETACHEDWARNING, IDS_APPNAME, MB_YESNOCANCEL | MB_ICONWARNING);
 		if (retval == IDYES)
 		{
-			if (CreateBranchTag(FALSE, NULL, true) == FALSE)
+			if (!CreateBranchTag(false, nullptr, true, defaultBranchName))
 				return true;
 		}
 		else if (retval == IDCANCEL)
@@ -1197,7 +1197,7 @@ int CAppUtils::CheckHeadDetach()
 	return false;
 }
 
-bool CAppUtils::CreateBranchTag(bool IsTag, const CString* CommitHash, bool switch_new_brach)
+bool CAppUtils::CreateBranchTag(bool IsTag, const CString* CommitHash, bool switch_new_brach, const CString& defaultBranchName)
 {
 	CCreateBranchTagDlg dlg;
 	dlg.m_bIsTag=IsTag;
@@ -1205,6 +1205,8 @@ bool CAppUtils::CreateBranchTag(bool IsTag, const CString* CommitHash, bool swit
 
 	if(CommitHash)
 		dlg.m_initialRefName = *CommitHash;
+
+	dlg.m_BranchTagName = defaultBranchName;
 
 	if(dlg.DoModal()==IDOK)
 	{

--- a/src/TortoiseProc/AppUtils.cpp
+++ b/src/TortoiseProc/AppUtils.cpp
@@ -1180,6 +1180,23 @@ bool CAppUtils::Export(const CString* BashHash, const CTGitPath* orgPath)
 	return false;
 }
 
+int CAppUtils::CheckHeadDetach()
+{
+	CString output;
+	if (CGit::GetCurrentBranchFromFile(g_Git.m_CurrentDir, output))
+	{
+		int retval = CMessageBox::Show(NULL, IDS_PROC_COMMIT_DETACHEDWARNING, IDS_APPNAME, MB_YESNOCANCEL | MB_ICONWARNING);
+		if (retval == IDYES)
+		{
+			if (CreateBranchTag(FALSE, NULL, true) == FALSE)
+				return true;
+		}
+		else if (retval == IDCANCEL)
+			return true;
+	}
+	return false;
+}
+
 bool CAppUtils::CreateBranchTag(bool IsTag, const CString* CommitHash, bool switch_new_brach)
 {
 	CCreateBranchTagDlg dlg;

--- a/src/TortoiseProc/AppUtils.h
+++ b/src/TortoiseProc/AppUtils.h
@@ -155,8 +155,8 @@ public:
 												bool bCompact = false);
 
 	static bool Export(const CString* BashHash = nullptr, const CTGitPath* orgPath = nullptr);
-	static int  CheckHeadDetach();
-	static bool CreateBranchTag(bool IsTag = TRUE, const CString* CommitHash = nullptr, bool switch_new_brach = false);
+	static int  CheckHeadDetach(const CString& defaultBranchNames = L"");
+	static bool CreateBranchTag(bool IsTag = TRUE, const CString* CommitHash = nullptr, bool switch_new_brach = false, const CString& defaultBranchName = L"");
 	static bool Switch(const CString& initialRefName = CString());
 	static bool PerformSwitch(const CString& ref, bool bForce = false, const CString& sNewBranch = CString(), bool bBranchOverride = false, BOOL bTrack = 2, bool bMerge = false);
 

--- a/src/TortoiseProc/AppUtils.h
+++ b/src/TortoiseProc/AppUtils.h
@@ -155,6 +155,7 @@ public:
 												bool bCompact = false);
 
 	static bool Export(const CString* BashHash = nullptr, const CTGitPath* orgPath = nullptr);
+	static int  CheckHeadDetach();
 	static bool CreateBranchTag(bool IsTag = TRUE, const CString* CommitHash = nullptr, bool switch_new_brach = false);
 	static bool Switch(const CString& initialRefName = CString());
 	static bool PerformSwitch(const CString& ref, bool bForce = false, const CString& sNewBranch = CString(), bool bBranchOverride = false, BOOL bTrack = 2, bool bMerge = false);

--- a/src/TortoiseProc/CommitDlg.cpp
+++ b/src/TortoiseProc/CommitDlg.cpp
@@ -881,7 +881,7 @@ void CCommitDlg::OnOK()
 		}
 	}
 
-	if (bAddSuccess && m_bWarnDetachedHead && CheckHeadDetach())
+	if (bAddSuccess && m_bWarnDetachedHead && CAppUtils::CheckHeadDetach())
 		bAddSuccess = false;
 
 	m_sBugID.Trim();
@@ -2516,23 +2516,6 @@ void CCommitDlg::OnHdnItemchangedFilelist(NMHDR * /*pNMHDR*/, LRESULT *pResult)
 {
 	*pResult = 0;
 	TRACE("Item Changed\r\n");
-}
-
-int CCommitDlg::CheckHeadDetach()
-{
-	CString output;
-	if (CGit::GetCurrentBranchFromFile(g_Git.m_CurrentDir, output))
-	{
-		int retval = CMessageBox::Show(NULL, IDS_PROC_COMMIT_DETACHEDWARNING, IDS_APPNAME, MB_YESNOCANCEL | MB_ICONWARNING);
-		if(retval == IDYES)
-		{
-			if (CAppUtils::CreateBranchTag(FALSE, NULL, true) == FALSE)
-				return 1;
-		}
-		else if (retval == IDCANCEL)
-			return 1;
-	}
-	return 0;
 }
 
 void CCommitDlg::OnBnClickedCommitAmenddiff()

--- a/src/TortoiseProc/CommitDlg.h
+++ b/src/TortoiseProc/CommitDlg.h
@@ -164,8 +164,6 @@ protected:
 	BOOL				m_bSetAuthor;
 	CString				m_sAuthor;
 
-	int					CheckHeadDetach();
-
 private:
 	CWinThread*			m_pThread;
 	std::map<CString, int>	m_autolist;

--- a/src/TortoiseProc/RebaseDlg.cpp
+++ b/src/TortoiseProc/RebaseDlg.cpp
@@ -993,7 +993,7 @@ void CRebaseDlg::OnBnClickedContinue()
 	if( m_RebaseStage == REBASE_DONE)
 	{
 		OnOK();
-		CAppUtils::CheckHeadDetach();
+		CAppUtils::CheckHeadDetach(m_OrigHEADBranch);
 		CheckRestoreStash();
 		return;
 	}

--- a/src/TortoiseProc/RebaseDlg.cpp
+++ b/src/TortoiseProc/RebaseDlg.cpp
@@ -993,6 +993,7 @@ void CRebaseDlg::OnBnClickedContinue()
 	if( m_RebaseStage == REBASE_DONE)
 	{
 		OnOK();
+		CAppUtils::CheckHeadDetach();
 		CheckRestoreStash();
 		return;
 	}


### PR DESCRIPTION
When choosing a non-local branch, such as FETCH_HEAD, as Branch,
the HEAD is still detached after rebase done.

Therefor, it's needed to warn user and provide a way to create new branch,
so that the changes might be not lost for further operation, such as checkout.
