### PR TITLE
Show cloning progress roughly via calculating the number of object directories

### DIFF
--- a/src/TortoiseProc/Commands/CloneCommand.cpp
+++ b/src/TortoiseProc/Commands/CloneCommand.cpp
@@ -258,6 +258,23 @@ bool CloneCommand::Execute()
 		CProgressDlg progress;
 		progress.m_GitCmd=cmd;
 		progress.m_PostCmdCallback = postCmdCallback;
+		progress.m_ProgressCallback = [&](int& percentage, CWnd& currentWorkCtrl)
+		{
+			CString str;
+			currentWorkCtrl.GetWindowText(str);
+			if (!str.IsEmpty())
+				return false;
+			CString filePathName = dlg.m_Directory + L"\\.git\\objects\\*";
+			CFileFind find;
+			if (!find.FindFile(filePathName))
+				return false;
+			int dirNum = 1;
+			while (find.FindNextFile())
+				dirNum++;
+			percentage = 10 * dirNum / 26; // There are 260 directories maximum (includeing "." and ".."), when the repo is not packed.
+			ATLTRACE(L"Percentage: %d\n", percentage);
+			return true;
+		};
 		INT_PTR ret = progress.DoModal();
 
 		if (dlg.m_bSVN)

--- a/src/TortoiseProc/ProgressDlg.h
+++ b/src/TortoiseProc/ProgressDlg.h
@@ -76,6 +76,7 @@ public:
 
 typedef std::vector<PostCmd> PostCmdList;
 typedef std::function<void(DWORD status, PostCmdList&)> PostCmdCallback;
+typedef std::function<bool(int& percentage, CWnd& currentWorkCtrl)> ProgressCallback;
 
 class CProgressDlg : public CResizableStandAloneDialog
 {
@@ -107,6 +108,8 @@ public:
 
 	CString					GetLogText() const { CString text; m_Log.GetWindowText(text); return text; }
 
+	ProgressCallback		m_ProgressCallback;
+
 private:
 	PostCmdList				m_PostCmdList;
 	void					WriteLog() const;
@@ -136,6 +139,8 @@ private:
 
 	afx_msg LRESULT			OnTaskbarBtnCreated(WPARAM wParam, LPARAM lParam);
 	CComPtr<ITaskbarList3>	m_pTaskbarList;
+
+	afx_msg void			OnTimer(UINT_PTR nIDEvent);
 
 	void					OnCancel();
 	afx_msg void			OnClose();


### PR DESCRIPTION
This is useful when cloning a big repository **locally**.
Because git.exe will not respond for a long time and the **ReadFile()** is not return during cloning the objects, I just create a timer to do that.
And CProgressDlg is a general purpose dialog, so I use callback.

"roughly" means I don't/can't consider the pack situation. :P

----
BTW, it is my first time to use callback function and lambda function. ^_^