### PR TITLE
Fix: Error message box is no longer shown while committing

### DIFF
--- a/src/TortoiseProc/MassiveGitTask.cpp
+++ b/src/TortoiseProc/MassiveGitTask.cpp
@@ -20,7 +20,6 @@
 
 #include "stdafx.h"
 #include "MassiveGitTask.h"
-#include "MessageBox.h"
 
 CMassiveGitTask::CMassiveGitTask(CString gitParameters, BOOL isPath, bool ignoreErrors)
 	: CMassiveGitTaskBase(gitParameters, isPath, ignoreErrors)
@@ -38,7 +37,7 @@ void CMassiveGitTask::ReportError(const CString& out)
 	if (m_NotifyCallbackInstance)
 		m_NotifyCallbackInstance->ReportError(out);
 	else
-		CMessageBox::Show(NULL, out, _T("TortoiseGit"), MB_OK | MB_ICONERROR);
+		__super::ReportError(out);
 }
 
 void CMassiveGitTask::ReportProgress(const CTGitPath& path, int index)

--- a/src/TortoiseProc/MassiveGitTask.cpp
+++ b/src/TortoiseProc/MassiveGitTask.cpp
@@ -20,6 +20,7 @@
 
 #include "stdafx.h"
 #include "MassiveGitTask.h"
+#include "MessageBox.h"
 
 CMassiveGitTask::CMassiveGitTask(CString gitParameters, BOOL isPath, bool ignoreErrors)
 	: CMassiveGitTaskBase(gitParameters, isPath, ignoreErrors)
@@ -36,6 +37,8 @@ void CMassiveGitTask::ReportError(const CString& out)
 {
 	if (m_NotifyCallbackInstance)
 		m_NotifyCallbackInstance->ReportError(out);
+	else
+		CMessageBox::Show(NULL, out, _T("TortoiseGit"), MB_OK | MB_ICONERROR);
 }
 
 void CMassiveGitTask::ReportProgress(const CTGitPath& path, int index)


### PR DESCRIPTION
while testing rename filename with changing case only, I found the bug that 
1. autocrlf = true & safecrlf = true
2. commit file with LF EOLs.
3. commit dialog keep to stay there and no error message.

I trace to 45a0c549d79a03cb703b07bb226d003e07b08ac4.

I don't quite understand what "regression" means.
Does it correct to add "Regression of 45a0c549d79a03cb703b07bb226d003e07b08ac4" into log message?


