### PR TITLE
Fixed issue #2376: Accidental stash-pops can so easily overwrite the uncommited working dir changes

### DIFF
--- a/Languages/Tortoise.pot
+++ b/Languages/Tortoise.pot
@@ -9291,6 +9291,10 @@ msgstr ""
 msgid "The working tree is not clean and contains unstaged changes.\nReview and commit the changes?"
 msgstr ""
 
+#. Resource IDs: (603)
+msgid "The working tree is not clean!\nDo you want to stash pop/apply changes?"
+msgstr ""
+
 #. Resource IDs: (65535)
 msgid "Their file:"
 msgstr ""

--- a/src/Changelog.txt
+++ b/src/Changelog.txt
@@ -3,6 +3,7 @@ Released: Unreleased
 
 == Features ==
  * Fixed issue #2441: A way to disable the sound that is played on errors
+ * Fixed issue #2376: Accidental stash-pops can so easily overwrite the uncommited working dir changes
 
 == Bug Fixes ==
  * Fixed issue #2427: "Submodule of Project: " cannot be localized

--- a/src/Resources/TortoiseProcENG.rc
+++ b/src/Resources/TortoiseProcENG.rc
@@ -4260,6 +4260,7 @@ BEGIN
     IDS_MENU_APPLY          "Apply Patch..."
     IDS_MENU_SENDMAIL       "Send Mail..."
     IDS_ERROR_NOREF         "No reference found"
+    IDS_WARN_NOCLEAN        "The working tree is not clean!\nDo you want to stash pop/apply changes?"
     IDS_ERROR_NOCLEAN_STASH "The current working tree is not clean.\nDo you want to stash the changes?"
     IDS_ERROR_NOTHING_COMMIT "Nothing to commit"
     IDS_COMMIT_FINISH       "Commit Finish"

--- a/src/TortoiseProc/AppUtils.h
+++ b/src/TortoiseProc/AppUtils.h
@@ -168,6 +168,8 @@ public:
 	static bool StashApply(CString ref, bool showChanges = true);
 	static bool	StashPop(bool showChanges = true);
 
+	static bool CheckCleanWorkTreeAndWarn();
+
 	static bool IsSSHPutty();
 
 	static bool LaunchRemoteSetting();

--- a/src/TortoiseProc/Settings/SettingsAdvanced.cpp
+++ b/src/TortoiseProc/Settings/SettingsAdvanced.cpp
@@ -90,6 +90,10 @@ CSettingsAdvanced::CSettingsAdvanced()
 	settings[i].type	= CSettingsAdvanced::SettingTypeBoolean;
 	settings[i++].def.b	= false;
 
+	settings[i].sName	= L"NoWarnStashPop";
+	settings[i].type	= CSettingsAdvanced::SettingTypeBoolean;
+	settings[i++].def.b = true;
+
 	settings[i].sName	= L"NumDiffWarning";
 	settings[i].type	= CSettingsAdvanced::SettingTypeNumber;
 	settings[i++].def.l	= 10;

--- a/src/TortoiseProc/SyncDlg.cpp
+++ b/src/TortoiseProc/SyncDlg.cpp
@@ -1514,6 +1514,14 @@ void CSyncDlg::OnBnClickedButtonSubmodule()
 
 void CSyncDlg::OnBnClickedButtonStash()
 {
+	INT_PTR curEntry = m_ctrlStash.GetCurrentEntry();
+
+	if (curEntry == 1 || curEntry == 2)
+	{
+		if (!CAppUtils::CheckCleanWorkTreeAndWarn())
+			return;
+	}
+
 	UpdateData();
 	UpdateCombox();
 	m_ctrlCmdOut.SetWindowTextW(_T(""));
@@ -1531,7 +1539,7 @@ void CSyncDlg::OnBnClickedButtonStash()
 	m_ctrlTabCtrl.ShowTab(IDC_IN_CONFLICT -1, false);
 
 	CString cmd;
-	switch (m_ctrlStash.GetCurrentEntry())
+	switch (curEntry)
 	{
 	case 0:
 		cmd = _T("git.exe stash save");

--- a/src/TortoiseProc/resource.h
+++ b/src/TortoiseProc/resource.h
@@ -1876,6 +1876,7 @@
 #define IDS_MENU_APPLY                  9635
 #define IDS_MENU_SENDMAIL               9636
 #define IDS_ERROR_NOREF                 9638
+#define IDS_WARN_NOCLEAN                9640
 #define IDS_ERROR_NOCLEAN_STASH         9641
 #define IDS_ERROR_NOTHING_COMMIT        9642
 #define IDS_COMMIT_FINISH               9643


### PR DESCRIPTION
cf : [Issue 2376](https://code.google.com/p/tortoisegit/issues/detail?id=2376)

I don't think stash pop can **easily** overwrite the uncommited changes after reading [this](https://github.com/git/git/commit/e0e2a9cbfa938d0f1e9857d5ca5b196360663440).
(After git 1.7.5.1, git drop dirty worktree check on apply.)

So, I think a warning message box is enough. agree?
If you disagree it, feel free to close this PR. :)

Also warn for **git stash apply**? Maybe not.
