### PR TITLE
"Abort merge" should work like "git merge --abort"

### DIFF
--- a/Languages/Tortoise.pot
+++ b/Languages/Tortoise.pot
@@ -1579,6 +1579,10 @@ msgstr ""
 msgid "Abort Merge"
 msgstr ""
 
+#. Resource IDs: (1554)
+msgid "Abort Type"
+msgstr ""
+
 #. Resource IDs: (15)
 msgid "Aborts a running merge."
 msgstr ""
@@ -5523,10 +5527,6 @@ msgstr ""
 msgid "In Commits"
 msgstr ""
 
-#. Resource IDs: (1649)
-msgid "In order to abort a merge progess a reset (to HEAD) is needed."
-msgstr ""
-
 #. Resource IDs: (1499)
 msgid "Include &Tags"
 msgstr ""
@@ -6004,6 +6004,10 @@ msgstr ""
 #. Resource IDs: (1252)
 #, c-format
 msgid "Merge to \"%s\"..."
+msgstr ""
+
+#. Resource IDs: (1550)
+msgid "Merge: Reset files related to this merge in working tree and index"
 msgstr ""
 
 #. Resource IDs: (263, 1257)

--- a/src/Changelog.txt
+++ b/src/Changelog.txt
@@ -3,6 +3,7 @@ Released: Unreleased
 
 == Features ==
  * Fixed issue #2441: A way to disable the sound that is played on errors
+ * Fixed issue #2429: TortoiseGit "Abort merge" should work like "git merge --abort"
 
 == Bug Fixes ==
  * Fixed issue #2427: "Submodule of Project: " cannot be localized

--- a/src/Resources/TortoiseProcENG.rc
+++ b/src/Resources/TortoiseProcENG.rc
@@ -1953,7 +1953,9 @@ STYLE DS_SETFONT | DS_MODALFRAME | DS_FIXEDSYS | WS_POPUP | WS_CAPTION | WS_SYSM
 CAPTION "Abort Merge"
 FONT 8, "MS Shell Dlg", 400, 0, 0x1
 BEGIN
-    GROUPBOX        "Reset Type",IDC_GROUP_RESET_TYPE,7,21,285,42
+    GROUPBOX        "Abort Type",IDC_GROUP_RESET_TYPE,7,7,285,56
+    CONTROL         "Merge: Reset files related to this merge in working tree and index",IDC_RADIO_ABORT_MERGE,
+                    "Button",BS_AUTORADIOBUTTON,15,20,270,10
     CONTROL         "Mixed: Leave working tree untouched, reset index",IDC_RADIO_RESET_MIXED,
                     "Button",BS_AUTORADIOBUTTON,15,33,270,10
     CONTROL         "Hard: Reset working tree and index (discard all local changes)",IDC_RADIO_RESET_HARD,
@@ -1962,7 +1964,6 @@ BEGIN
     DEFPUSHBUTTON   "OK",IDOK,125,90,50,14
     PUSHBUTTON      "Cancel",IDCANCEL,184,90,50,14
     PUSHBUTTON      "Help",IDHELP,242,90,50,14
-    LTEXT           "In order to abort a merge progess a reset (to HEAD) is needed.",IDC_STATIC_REMINDER,7,7,285,10
 END
 
 IDD_SETTINGSDIALOGS3 DIALOGEX 0, 0, 301, 231

--- a/src/TortoiseProc/MergeAbortDlg.cpp
+++ b/src/TortoiseProc/MergeAbortDlg.cpp
@@ -33,7 +33,10 @@ CMergeAbortDlg::CMergeAbortDlg(CWnd* pParent /*=NULL*/)
 	: CStateStandAloneDialog(CMergeAbortDlg::IDD, pParent)
 	, m_ResetType(2)
 {
-
+	CString WorkingDir = g_Git.m_CurrentDir;
+	WorkingDir.Replace(_T(':'), _T('_'));
+	m_regResetType = CRegDWORD(_T("Software\\TortoiseGit\\History\\MergeAbort\\") + WorkingDir, 2);
+	m_ResetType = (int)m_regResetType;
 }
 
 CMergeAbortDlg::~CMergeAbortDlg()
@@ -76,6 +79,7 @@ void CMergeAbortDlg::OnOK()
 {
 	this->UpdateData(TRUE);
 	m_ResetType = this->GetCheckedRadioButton(IDC_RADIO_ABORT_MERGE, IDC_RADIO_RESET_HARD) - IDC_RADIO_ABORT_MERGE;
+	m_regResetType = m_ResetType;
 	return CStateStandAloneDialog::OnOK();
 }
 

--- a/src/TortoiseProc/MergeAbortDlg.cpp
+++ b/src/TortoiseProc/MergeAbortDlg.cpp
@@ -1,6 +1,6 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
-// Copyright (C) 2008-2013 - TortoiseGit
+// Copyright (C) 2008-2013, 2015 - TortoiseGit
 
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -31,7 +31,7 @@ IMPLEMENT_DYNAMIC(CMergeAbortDlg, CStateStandAloneDialog)
 
 CMergeAbortDlg::CMergeAbortDlg(CWnd* pParent /*=NULL*/)
 	: CStateStandAloneDialog(CMergeAbortDlg::IDD, pParent)
-	, m_ResetType(1)
+	, m_ResetType(2)
 {
 
 }
@@ -61,12 +61,13 @@ BOOL CMergeAbortDlg::OnInitDialog()
 	GetWindowText(sWindowTitle);
 	CAppUtils::SetWindowTitle(m_hWnd, g_Git.m_CurrentDir, sWindowTitle);
 
+	AdjustControlSize(IDC_RADIO_ABORT_MERGE);
 	AdjustControlSize(IDC_RADIO_RESET_MIXED);
 	AdjustControlSize(IDC_RADIO_RESET_HARD);
 
 	EnableSaveRestore(_T("MergeAbortDlg"));
 
-	this->CheckRadioButton(IDC_RADIO_RESET_MIXED, IDC_RADIO_RESET_HARD, IDC_RADIO_RESET_MIXED + m_ResetType);
+	this->CheckRadioButton(IDC_RADIO_ABORT_MERGE, IDC_RADIO_RESET_HARD, IDC_RADIO_ABORT_MERGE + m_ResetType);
 
 	return FALSE;
 }
@@ -74,7 +75,7 @@ BOOL CMergeAbortDlg::OnInitDialog()
 void CMergeAbortDlg::OnOK()
 {
 	this->UpdateData(TRUE);
-	m_ResetType = this->GetCheckedRadioButton(IDC_RADIO_RESET_MIXED, IDC_RADIO_RESET_HARD) - IDC_RADIO_RESET_MIXED;
+	m_ResetType = this->GetCheckedRadioButton(IDC_RADIO_ABORT_MERGE, IDC_RADIO_RESET_HARD) - IDC_RADIO_ABORT_MERGE;
 	return CStateStandAloneDialog::OnOK();
 }
 

--- a/src/TortoiseProc/MergeAbortDlg.h
+++ b/src/TortoiseProc/MergeAbortDlg.h
@@ -39,6 +39,9 @@ protected:
 	afx_msg void OnBnClickedShowModifiedFiles();
 
 	DECLARE_MESSAGE_MAP()
+
+	CRegDWORD m_regResetType;
+
 public:
 	int m_ResetType;
 };

--- a/src/TortoiseProc/resource.h
+++ b/src/TortoiseProc/resource.h
@@ -1201,6 +1201,7 @@
 #define IDC_MSYSGIT_PATH                1550
 #define IDS_PROC_RENAME                 1550
 #define IDC_RADIO_RESET_SOFT            1550
+#define IDC_RADIO_ABORT_MERGE           1550
 #define IDC_SHOWDELETEDOVERLAY          1551
 #define IDC_MSYSGIT_BROWSE              1551
 #define IDS_PROC_NEWNAME                1551


### PR DESCRIPTION
"Abort merge" should work like "git merge --abort"
Fixes issue 2429
- [x] git.exe merge --abort
- [ ] libgit2 backend
- [ ] Update doc
