### PR TITLE
GitAdminDir cleanup

### DIFF
--- a/src/Git/Git.cpp
+++ b/src/Git/Git.cpp
@@ -831,7 +831,7 @@ int CGit::GetCurrentBranchFromFile(const CString &sProjectRoot, CString &sBranch
 		return -1;
 
 	CString sDotGitPath;
-	if (!g_GitAdminDir.GetAdminDirPath(sProjectRoot, sDotGitPath))
+	if (!GitAdminDir::GetAdminDirPath(sProjectRoot, sDotGitPath))
 		return -1;
 
 	CString sHeadFile = sDotGitPath + _T("HEAD");
@@ -1519,7 +1519,7 @@ bool CGit::BranchTagExists(const CString& name, bool isBranch /*= true*/)
 CString CGit::DerefFetchHead()
 {
 	CString dotGitPath;
-	g_GitAdminDir.GetAdminDirPath(m_CurrentDir, dotGitPath);
+	GitAdminDir::GetAdminDirPath(m_CurrentDir, dotGitPath);
 	std::ifstream fetchHeadFile((dotGitPath + L"FETCH_HEAD").GetString(), std::ios::in | std::ios::binary);
 	int forMergeLineCount = 0;
 	std::string line;
@@ -2116,7 +2116,7 @@ CString CGit::GetHomeDirectory() const
 CString CGit::GetGitLocalConfig() const
 {
 	CString path;
-	g_GitAdminDir.GetAdminDirPath(m_CurrentDir, path);
+	GitAdminDir::GetAdminDirPath(m_CurrentDir, path);
 	path += _T("config");
 	return path;
 }

--- a/src/Git/Git.h
+++ b/src/Git/Git.h
@@ -250,8 +250,8 @@ public:
 	static CString GetLibGit2LastErr(const CString& msg);
 	bool SetCurrentDir(CString path, bool submodule = false)
 	{
-		bool b = g_GitAdminDir.HasAdminDir(path, submodule ? false : !!PathIsDirectory(path), &m_CurrentDir);
-		if (!b && g_GitAdminDir.IsBareRepo(path))
+		bool b = GitAdminDir::HasAdminDir(path, submodule ? false : !!PathIsDirectory(path), &m_CurrentDir);
+		if (!b && GitAdminDir::IsBareRepo(path))
 		{
 			m_CurrentDir = path;
 			b = true;

--- a/src/Git/Git.h
+++ b/src/Git/Git.h
@@ -79,7 +79,6 @@ public:
 class CGit
 {
 private:
-	GitAdminDir m_GitDir;
 	CString		gitLastErr;
 protected:
 	bool m_IsGitDllInited;
@@ -251,7 +250,7 @@ public:
 	static CString GetLibGit2LastErr(const CString& msg);
 	bool SetCurrentDir(CString path, bool submodule = false)
 	{
-		bool b = m_GitDir.HasAdminDir(path, submodule ? false : !!PathIsDirectory(path), &m_CurrentDir);
+		bool b = g_GitAdminDir.HasAdminDir(path, submodule ? false : !!PathIsDirectory(path), &m_CurrentDir);
 		if (!b && g_GitAdminDir.IsBareRepo(path))
 		{
 			m_CurrentDir = path;

--- a/src/Git/GitAdminDir.cpp
+++ b/src/Git/GitAdminDir.cpp
@@ -39,9 +39,12 @@ CString GitAdminDir::GetSuperProjectRoot(const CString& path)
 
 	do
 	{
-		if(CGit::GitPathFileExists(projectroot + _T("\\.gitmodules")))
+		if (CGit::GitPathFileExists(projectroot + _T("\\.git")))
 		{
-			return projectroot;
+			if (CGit::GitPathFileExists(projectroot + _T("\\.gitmodules")))
+				return projectroot;
+			else
+				return _T("");
 		}
 
 		projectroot = projectroot.Left(projectroot.ReverseFind('\\'));

--- a/src/Git/GitAdminDir.cpp
+++ b/src/Git/GitAdminDir.cpp
@@ -1,6 +1,6 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
-// Copyright (C) 2008-2014 - TortoiseGit
+// Copyright (C) 2008-2015 - TortoiseGit
 // Copyright (C) 2003-2008 - TortoiseSVN
 
 // This program is free software; you can redistribute it and/or
@@ -55,7 +55,6 @@ CString GitAdminDir::GetSuperProjectRoot(const CString& path)
 CString GitAdminDir::GetGitTopDir(const CString& path)
 {
 	CString str;
-	str=_T("");
 	HasAdminDir(path,!!PathIsDirectory(path),&str);
 	return str;
 }

--- a/src/Git/GitAdminDir.cpp
+++ b/src/Git/GitAdminDir.cpp
@@ -63,6 +63,11 @@ CString GitAdminDir::GetGitTopDir(const CString& path)
 	return str;
 }
 
+bool GitAdminDir::IsWorkingTreeOrBareRepo(const CString& path)
+{
+	return HasAdminDir(path) || IsBareRepo(path);
+}
+
 bool GitAdminDir::HasAdminDir(const CString& path)
 {
 	return HasAdminDir(path, !!PathIsDirectory(path));

--- a/src/Git/GitAdminDir.cpp
+++ b/src/Git/GitAdminDir.cpp
@@ -23,8 +23,6 @@
 #include "Git.h"
 #include <memory>
 
-GitAdminDir g_GitAdminDir;
-
 GitAdminDir::GitAdminDir()
 {
 }
@@ -65,17 +63,17 @@ CString GitAdminDir::GetGitTopDir(const CString& path)
 	return str;
 }
 
-bool GitAdminDir::HasAdminDir(const CString& path) const
+bool GitAdminDir::HasAdminDir(const CString& path)
 {
 	return HasAdminDir(path, !!PathIsDirectory(path));
 }
 
-bool GitAdminDir::HasAdminDir(const CString& path,CString *ProjectTopDir) const
+bool GitAdminDir::HasAdminDir(const CString& path,CString* ProjectTopDir)
 {
 	return HasAdminDir(path, !!PathIsDirectory(path),ProjectTopDir);
 }
 
-bool GitAdminDir::HasAdminDir(const CString& path, bool bDir,CString *ProjectTopDir) const
+bool GitAdminDir::HasAdminDir(const CString& path, bool bDir, CString* ProjectTopDir)
 {
 	if (path.IsEmpty())
 		return false;
@@ -141,7 +139,7 @@ bool GitAdminDir::HasAdminDir(const CString& path, bool bDir,CString *ProjectTop
  * Returns the .git-path (if .git is a file, read the repository path and return it)
  * adminDir always ends with "\"
  */
-bool GitAdminDir::GetAdminDirPath(const CString &projectTopDir, CString &adminDir) const
+bool GitAdminDir::GetAdminDirPath(const CString &projectTopDir, CString& adminDir)
 {
 	if (IsBareRepo(projectTopDir))
 	{
@@ -151,7 +149,7 @@ bool GitAdminDir::GetAdminDirPath(const CString &projectTopDir, CString &adminDi
 		return true;
 	}
 
-	CString sDotGitPath = projectTopDir + _T("\\") + g_GitAdminDir.GetAdminDirName();
+	CString sDotGitPath = projectTopDir + _T("\\") + GetAdminDirName();
 	if (CTGitPath(sDotGitPath).IsDirectory())
 	{
 		sDotGitPath.TrimRight('\\');
@@ -191,7 +189,7 @@ bool GitAdminDir::GetAdminDirPath(const CString &projectTopDir, CString &adminDi
 	}
 }
 
-bool GitAdminDir::IsAdminDirPath(const CString& path) const
+bool GitAdminDir::IsAdminDirPath(const CString& path)
 {
 	if (path.IsEmpty())
 		return false;
@@ -217,7 +215,7 @@ bool GitAdminDir::IsAdminDirPath(const CString& path) const
 	return bIsAdminDir;
 }
 
-bool GitAdminDir::IsBareRepo(const CString& path) const
+bool GitAdminDir::IsBareRepo(const CString& path)
 {
 	if (path.IsEmpty())
 		return false;

--- a/src/Git/GitAdminDir.cpp
+++ b/src/Git/GitAdminDir.cpp
@@ -49,6 +49,9 @@ CString GitAdminDir::GetSuperProjectRoot(const CString& path)
 
 		projectroot = projectroot.Left(projectroot.ReverseFind('\\'));
 
+		// don't check for \\COMPUTERNAME\.git
+		if (projectroot[0] == _T('\\') && projectroot[1] == _T('\\') && projectroot.Find(_T('\\'), 2) < 0)
+			return _T("");
 	}while(projectroot.ReverseFind('\\')>0);
 
 	return _T("");
@@ -126,6 +129,9 @@ bool GitAdminDir::HasAdminDir(const CString& path, bool bDir,CString *ProjectTop
 			break;
 
 		sDirName = sDirName.Left(x);
+		// don't check for \\COMPUTERNAME\.git
+		if (sDirName[0] == _T('\\') && sDirName[1] == _T('\\') && sDirName.Find(_T('\\'), 2) < 0)
+			break;
 	}
 
 	return false;

--- a/src/Git/GitAdminDir.h
+++ b/src/Git/GitAdminDir.h
@@ -29,6 +29,8 @@ public:
 	/// Returns true if the path points to or below an admin directory
 	static bool IsAdminDirPath(const CString& path);
 
+	static bool IsWorkingTreeOrBareRepo(const CString& path);
+
 	/// Returns true if the path points is a bare repository
 	static bool IsBareRepo(const CString& path);
 

--- a/src/Git/GitAdminDir.h
+++ b/src/Git/GitAdminDir.h
@@ -1,6 +1,6 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
-// Copyright (C) 2008-2012 - TortoiseGit
+// Copyright (C) 2008-2012, 2015 - TortoiseGit
 // Copyright (C) 2003-2008 - TortoiseSVN
 
 // This program is free software; you can redistribute it and/or
@@ -22,28 +22,26 @@
 
 class GitAdminDir
 {
-public:
+private:
 	GitAdminDir(void);
 	~GitAdminDir(void);
-
+public:
 	/// Returns true if the path points to or below an admin directory
-	bool IsAdminDirPath(const CString& path) const;
+	static bool IsAdminDirPath(const CString& path);
 
 	/// Returns true if the path points is a bare repository
-	bool IsBareRepo(const CString& path) const;
+	static bool IsBareRepo(const CString& path);
 
 	/// Returns true if the path (file or folder) has an admin directory
 	/// associated, i.e. if the path is in a working copy.
-	bool HasAdminDir(const CString& path) const;
-	bool HasAdminDir(const CString& path,CString * ProjectTopDir) const;
-	bool HasAdminDir(const CString& path, bool bDir,CString * ProjectTopDir=NULL) const;
-	CString GetSuperProjectRoot(const CString& path);
+	static bool HasAdminDir(const CString& path);
+	static bool HasAdminDir(const CString& path, CString* ProjectTopDir);
+	static bool HasAdminDir(const CString& path, bool bDir, CString* ProjectTopDir = nullptr);
+	static CString GetSuperProjectRoot(const CString& path);
 
-	bool GetAdminDirPath(const CString &projectTopDir, CString &adminDir) const;
+	static bool GetAdminDirPath(const CString &projectTopDir, CString& adminDir);
 
-	CString GetGitTopDir(const CString& path);
+	static CString GetGitTopDir(const CString& path);
 
-	CString GetAdminDirName() const {return _T(".git");}
+	static CString GetAdminDirName() { return _T(".git"); }
 };
-
-extern GitAdminDir g_GitAdminDir;

--- a/src/Git/GitPatch.cpp
+++ b/src/Git/GitPatch.cpp
@@ -1,6 +1,6 @@
 // TortoiseGitMerge - a Diff/Patch program
 
-// Copyright (C) 2012-2013 - TortoiseGit
+// Copyright (C) 2012-2013, 2015 - TortoiseGit
 // Copyright (C) 2010-2012 - TortoiseSVN
 
 // This program is free software; you can redistribute it and/or
@@ -306,7 +306,7 @@ CString GitPatch::CheckPatchPath(const CString& path)
 			return path;
 		if (!isDir)
 			continue;
-		if (g_GitAdminDir.IsAdminDirPath(subpath))
+		if (GitAdminDir::IsAdminDirPath(subpath))
 			continue;
 		progress.SetLine(2, subpath, true);
 		if (CountMatches(subpath) > (GetNumberOfFiles()/3))

--- a/src/Git/TGitPath.cpp
+++ b/src/Git/TGitPath.cpp
@@ -758,7 +758,7 @@ bool CTGitPath::HasAdminDir() const
 		return m_bHasAdminDir;
 
 	EnsureBackslashPathSet();
-	m_bHasAdminDir = g_GitAdminDir.HasAdminDir(m_sBackslashPath, IsDirectory(), &m_sProjectRoot);
+	m_bHasAdminDir = GitAdminDir::HasAdminDir(m_sBackslashPath, IsDirectory(), &m_sProjectRoot);
 	m_bHasAdminDirKnown = true;
 	return m_bHasAdminDir;
 }
@@ -779,7 +779,7 @@ int CTGitPath::GetAdminDirMask() const
 {
 	int status = 0;
 	CString topdir;
-	if(!g_GitAdminDir.HasAdminDir(GetWinPathString(),&topdir))
+	if (!GitAdminDir::HasAdminDir(GetWinPathString(), &topdir))
 	{
 		return status;
 	}
@@ -795,7 +795,7 @@ int CTGitPath::GetAdminDirMask() const
 			status |= ITEMIS_WCROOT;
 
 			CString topProjectDir;
-			if (g_GitAdminDir.HasAdminDir(GetWinPathString(), false, &topProjectDir))
+			if (GitAdminDir::HasAdminDir(GetWinPathString(), false, &topProjectDir))
 			{
 				if (PathFileExists(topProjectDir + _T("\\.gitmodules")))
 				{
@@ -814,7 +814,7 @@ int CTGitPath::GetAdminDirMask() const
 	}
 
 	CString dotGitPath;
-	g_GitAdminDir.GetAdminDirPath(topdir, dotGitPath);
+	GitAdminDir::GetAdminDirPath(topdir, dotGitPath);
 
 	if (PathFileExists(dotGitPath + _T("BISECT_START")))
 		status |= ITEMIS_BISECT;
@@ -837,65 +837,65 @@ int CTGitPath::GetAdminDirMask() const
 bool CTGitPath::HasStashDir() const
 {
 	CString topdir;
-	if(!g_GitAdminDir.HasAdminDir(GetWinPathString(),&topdir))
+	if(!GitAdminDir::HasAdminDir(GetWinPathString(),&topdir))
 	{
 		return false;
 	}
 
 	CString dotGitPath;
-	g_GitAdminDir.GetAdminDirPath(topdir, dotGitPath);
+	GitAdminDir::GetAdminDirPath(topdir, dotGitPath);
 
 	return !!PathFileExists(dotGitPath + _T("\\refs\\stash"));
 }
 bool CTGitPath::HasGitSVNDir() const
 {
 	CString topdir;
-	if(!g_GitAdminDir.HasAdminDir(GetWinPathString(),&topdir))
+	if (!GitAdminDir::HasAdminDir(GetWinPathString(), &topdir))
 	{
 		return false;
 	}
 
 	CString dotGitPath;
-	g_GitAdminDir.GetAdminDirPath(topdir, dotGitPath);
+	GitAdminDir::GetAdminDirPath(topdir, dotGitPath);
 
 	return !!PathFileExists(dotGitPath + _T("svn"));
 }
 bool CTGitPath::IsBisectActive() const
 {
 	CString topdir;
-	if(!g_GitAdminDir.HasAdminDir(GetWinPathString(),&topdir))
+	if (!GitAdminDir::HasAdminDir(GetWinPathString(), &topdir))
 	{
 		return false;
 	}
 
 	CString dotGitPath;
-	g_GitAdminDir.GetAdminDirPath(topdir, dotGitPath);
+	GitAdminDir::GetAdminDirPath(topdir, dotGitPath);
 
 	return !!PathFileExists(dotGitPath + _T("BISECT_START"));
 }
 bool CTGitPath::IsMergeActive() const
 {
 	CString topdir;
-	if(!g_GitAdminDir.HasAdminDir(GetWinPathString(),&topdir))
+	if (!GitAdminDir::HasAdminDir(GetWinPathString(), &topdir))
 	{
 		return false;
 	}
 
 	CString dotGitPath;
-	g_GitAdminDir.GetAdminDirPath(topdir, dotGitPath);
+	GitAdminDir::GetAdminDirPath(topdir, dotGitPath);
 
 	return !!PathFileExists(dotGitPath + _T("MERGE_HEAD"));
 }
 bool CTGitPath::HasRebaseApply() const
 {
 	CString topdir;
-	if(!g_GitAdminDir.HasAdminDir(GetWinPathString(),&topdir))
+	if (!GitAdminDir::HasAdminDir(GetWinPathString(), &topdir))
 	{
 		return false;
 	}
 
 	CString dotGitPath;
-	g_GitAdminDir.GetAdminDirPath(topdir, dotGitPath);
+	GitAdminDir::GetAdminDirPath(topdir, dotGitPath);
 
 	return !!PathFileExists(dotGitPath + _T("rebase-apply"));
 }
@@ -910,7 +910,7 @@ bool CTGitPath::HasAdminDir(CString *ProjectTopDir) const
 	}
 
 	EnsureBackslashPathSet();
-	m_bHasAdminDir = g_GitAdminDir.HasAdminDir(m_sBackslashPath, IsDirectory(), &m_sProjectRoot);
+	m_bHasAdminDir = GitAdminDir::HasAdminDir(m_sBackslashPath, IsDirectory(), &m_sProjectRoot);
 	m_bHasAdminDirKnown = true;
 	if (ProjectTopDir)
 		*ProjectTopDir = m_sProjectRoot;
@@ -923,7 +923,7 @@ bool CTGitPath::IsAdminDir() const
 		return m_bIsAdminDir;
 
 	EnsureBackslashPathSet();
-	m_bIsAdminDir = g_GitAdminDir.IsAdminDirPath(m_sBackslashPath);
+	m_bIsAdminDir = GitAdminDir::IsAdminDirPath(m_sBackslashPath);
 	m_bIsAdminDirKnown = true;
 	return m_bIsAdminDir;
 }

--- a/src/TGitCache/CachedDirectory.cpp
+++ b/src/TGitCache/CachedDirectory.cpp
@@ -1,7 +1,7 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
 // External Cache Copyright (C) 2005-2008 - TortoiseSVN
-// Copyright (C) 2008-2014 - TortoiseGit
+// Copyright (C) 2008-2015 - TortoiseGit
 
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -387,7 +387,7 @@ CStatusCacheEntry CCachedDirectory::GetStatusForMember(const CTGitPath& path, bo
 	// We've not got this item in the cache - let's add it
 	// We never bother asking SVN for the status of just one file, always for its containing directory
 
-	if (g_GitAdminDir.IsAdminDirPath(path.GetWinPathString()))
+	if (GitAdminDir::IsAdminDirPath(path.GetWinPathString()))
 	{
 		// We're being asked for the status of an .git directory
 		// It's not worth asking for this

--- a/src/TGitCache/GITStatusCache.cpp
+++ b/src/TGitCache/GITStatusCache.cpp
@@ -1,7 +1,7 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
 // External Cache Copyright (C) 2005-2006,2008,2010,2014 - TortoiseSVN
-// Copyright (C) 2008-2014 - TortoiseGit
+// Copyright (C) 2008-2015 - TortoiseGit
 
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -486,7 +486,7 @@ CCachedDirectory * CGitStatusCache::GetDirectoryCacheEntry(const CTGitPath& path
 		}
 		// We don't know anything about this directory yet - lets add it to our cache
 		// but only if it exists!
-		if (path.Exists() && m_shellCache.IsPathAllowed(path.GetWinPath()) && !g_GitAdminDir.IsAdminDirPath(path.GetWinPath()))
+		if (path.Exists() && m_shellCache.IsPathAllowed(path.GetWinPath()) && !GitAdminDir::IsAdminDirPath(path.GetWinPath()))
 		{
 			// some notifications are for files which got removed/moved around.
 			// In such cases, the CTGitPath::IsDirectory() will return true (it assumes a directory if

--- a/src/TGitCache/ShellUpdater.cpp
+++ b/src/TGitCache/ShellUpdater.cpp
@@ -1,7 +1,7 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
 // External Cache Copyright (C) 2005-2008 - TortoiseSVN
-// Copyright (C) 2008-2011,2013 - TortoiseGit
+// Copyright (C) 2008-2011,2013,2015 - TortoiseGit
 
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -152,7 +152,7 @@ void CShellUpdater::WorkerThread()
 				// first send a notification about a sub folder change, so explorer doesn't discard
 				// the folder notification. Since we only know for sure that the git admin
 				// dir is present, we send a notification for that folder.
-				CString admindir = workingPath.GetWinPathString() + _T("\\") + g_GitAdminDir.GetAdminDirName();
+				CString admindir = workingPath.GetWinPathString() + _T("\\") + GitAdminDir::GetAdminDirName();
 				if(::PathFileExists(admindir))
 					SHChangeNotify(SHCNE_UPDATEITEM, SHCNF_PATH | SHCNF_FLUSHNOWAIT, (LPCTSTR)admindir, NULL);
 

--- a/src/TortoiseGitBlame/TortoiseGitBlameDoc.cpp
+++ b/src/TortoiseGitBlame/TortoiseGitBlameDoc.cpp
@@ -1,6 +1,6 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
-// Copyright (C) 2008-2014 - TortoiseGit
+// Copyright (C) 2008-2015 - TortoiseGit
 
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -110,9 +110,8 @@ BOOL CTortoiseGitBlameDoc::OnOpenDocument(LPCTSTR lpszPathName,CString Rev)
 		CCommonAppUtils::RunTortoiseGitProc(_T(" /command:settings"));
 		return FALSE;
 	}
-	GitAdminDir admindir;
 	CString topdir;
-	if(!admindir.HasAdminDir(m_CurrentFileName, &topdir))
+	if (!GitAdminDir::HasAdminDir(m_CurrentFileName, &topdir))
 	{
 		CString temp;
 		temp.Format(IDS_CANNOTBLAMENOGIT, CString(m_CurrentFileName));
@@ -121,7 +120,6 @@ BOOL CTortoiseGitBlameDoc::OnOpenDocument(LPCTSTR lpszPathName,CString Rev)
 	}
 	else
 	{
-		GitAdminDir lastAdminDir;
 		CString oldTopDir;
 		if (topdir != g_Git.m_CurrentDir && CTGitPath(g_Git.m_CurrentDir).HasAdminDir(&oldTopDir) && oldTopDir != topdir)
 		{

--- a/src/TortoiseMerge/MainFrm.cpp
+++ b/src/TortoiseMerge/MainFrm.cpp
@@ -1,6 +1,6 @@
 // TortoiseGitMerge - a Diff/Patch program
 
-// Copyright (C) 2008-2014 - TortoiseGit
+// Copyright (C) 2008-2015 - TortoiseGit
 // Copyright (C) 2004-2015 - TortoiseSVN
 // Copyright (C) 2012-2014 - Sven Strickroth <email@cs-ware.de>
 
@@ -1716,7 +1716,7 @@ bool CMainFrame::FileSave(bool bCheckResolved /*=true*/)
 	if (IsViewGood(m_pwndBottomView) && !m_bHasConflicts && bCheckResolved)
 	{
 		CString projectRoot;
-		if (g_GitAdminDir.HasAdminDir(m_Data.m_mergedFile.GetFilename(), false, &projectRoot))
+		if (GitAdminDir::HasAdminDir(m_Data.m_mergedFile.GetFilename(), false, &projectRoot))
 		{
 			CString subpath = m_Data.m_mergedFile.GetFilename();
 			subpath.Replace(_T('\\'), _T('/'));

--- a/src/TortoiseMerge/Patch.cpp
+++ b/src/TortoiseMerge/Patch.cpp
@@ -1,6 +1,6 @@
 // TortoiseGitMerge - a Diff/Patch program
 
-// Copyright (C) 2009-2013 - TortoiseGit
+// Copyright (C) 2009-2013, 2015 - TortoiseGit
 // Copyright (C) 2012-2013 - Sven Strickroth <email@cs-ware.de>
 // Copyright (C) 2004-2009,2011-2014 - TortoiseSVN
 
@@ -664,7 +664,7 @@ CString	CPatch::CheckPatchPath(const CString& path)
 	{
 		if (!isDir)
 			continue;
-		if (g_GitAdminDir.IsAdminDirPath(subpath))
+		if (GitAdminDir::IsAdminDirPath(subpath))
 			continue;
 		if (CountMatches(subpath) > (GetNumberOfFiles()/3))
 			return subpath;

--- a/src/TortoiseProc/AppUtils.cpp
+++ b/src/TortoiseProc/AppUtils.cpp
@@ -1446,7 +1446,7 @@ bool CAppUtils::IgnoreFile(const CTGitPathList& path,bool IsMask)
 				ignorefile += _T(".gitignore");
 				break;
 			case 2:
-				g_GitAdminDir.GetAdminDirPath(g_Git.m_CurrentDir, ignorefile);
+				GitAdminDir::GetAdminDirPath(g_Git.m_CurrentDir, ignorefile);
 				ignorefile += _T("info/exclude");
 				break;
 		}
@@ -2631,7 +2631,7 @@ static bool DoFetch(const CString& url, const bool fetchAllRemotes, const bool l
 
 		postCmdList.push_back(PostCmd(IDI_PULL, IDS_MENUFETCH, []{ CAppUtils::Fetch(); }));
 
-		if (!runRebase && !g_GitAdminDir.IsBareRepo(g_Git.m_CurrentDir))
+		if (!runRebase && !GitAdminDir::IsBareRepo(g_Git.m_CurrentDir))
 			postCmdList.push_back(PostCmd(IDI_REBASE, IDS_MENUREBASE, [&]{ runRebase = false; CAppUtils::RebaseAfterFetch(); }));
 	};
 
@@ -2759,7 +2759,7 @@ bool CAppUtils::Push(const CString& selectLocalBranch)
 		}
 
 		CString superprojectRoot;
-		g_GitAdminDir.HasAdminDir(g_Git.m_CurrentDir, false, &superprojectRoot);
+		GitAdminDir::HasAdminDir(g_Git.m_CurrentDir, false, &superprojectRoot);
 		progress.m_PostCmdCallback = [&](DWORD status, PostCmdList& postCmdList)
 		{
 			// need to execute hooks as those might be needed by post action commands

--- a/src/TortoiseProc/BrowseRefsDlg.cpp
+++ b/src/TortoiseProc/BrowseRefsDlg.cpp
@@ -1,6 +1,6 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
-// Copyright (C) 2009-2014 - TortoiseGit
+// Copyright (C) 2009-2015 - TortoiseGit
 
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -283,7 +283,7 @@ BOOL CBrowseRefsDlg::OnInitDialog()
 	GetWindowText(sWindowTitle);
 	CAppUtils::SetWindowTitle(m_hWnd, g_Git.m_CurrentDir, sWindowTitle);
 
-	m_bHasWC = !g_GitAdminDir.IsBareRepo(g_Git.m_CurrentDir);
+	m_bHasWC = !GitAdminDir::IsBareRepo(g_Git.m_CurrentDir);
 
 	if (m_bPickOne)
 		m_ListRefLeafs.ModifyStyle(0, LVS_SINGLESEL);

--- a/src/TortoiseProc/Commands/CommitCommand.cpp
+++ b/src/TortoiseProc/Commands/CommitCommand.cpp
@@ -1,6 +1,6 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
-// Copyright (C) 2008-2013 - TortoiseGit
+// Copyright (C) 2008-2013, 2015 - TortoiseGit
 // Copyright (C) 2007-2008 - TortoiseSVN
 
 // This program is free software; you can redistribute it and/or
@@ -52,7 +52,8 @@ bool CommitCommand::Execute()
 	CString sLogMsg = LoadLogMessage();
 	bool bSelectFilesForCommit = !!DWORD(CRegStdDWORD(_T("Software\\TortoiseGit\\SelectFilesForCommit"), TRUE));
 
-	if (!GitAdminDir().HasAdminDir(g_Git.m_CurrentDir)) {
+	if (!GitAdminDir::HasAdminDir(g_Git.m_CurrentDir))
+	{
 		CMessageBox::Show(hwndExplorer, IDS_NOWORKINGCOPY, IDS_APPNAME, MB_ICONERROR);
 		return false;
 	}

--- a/src/TortoiseProc/Commands/DiffCommand.cpp
+++ b/src/TortoiseProc/Commands/DiffCommand.cpp
@@ -1,7 +1,7 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
 // Copyright (C) 2007-2008 - TortoiseSVN
-// Copyright (C) 2007-2011, 2013-2014 - TortoiseGit
+// Copyright (C) 2007-2011, 2013-2015 - TortoiseGit
 
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -65,7 +65,7 @@ bool DiffCommand::Execute()
 					CBlockCacheForPath cacheBlock(topDir);
 					CAutoIndex index;
 					CString adminDir;
-					g_GitAdminDir.GetAdminDirPath(topDir, adminDir);
+					GitAdminDir::GetAdminDirPath(topDir, adminDir);
 					if (!git_index_open(index.GetPointer(), CUnicodeUtils::GetUTF8(adminDir + _T("index"))))
 						g_Git.Run(_T("git.exe update-index -- \"") + cmdLinePath.GetGitPathString() + _T("\""), nullptr); // make sure we get the right status
 					GitStatus::GetFileStatus(topDir, cmdLinePath.GetWinPathString(), &status, true);

--- a/src/TortoiseProc/Commands/DropCopyAddCommand.cpp
+++ b/src/TortoiseProc/Commands/DropCopyAddCommand.cpp
@@ -1,6 +1,6 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
-// Copyright (C) 2011,2013-2014 - TortoiseGit
+// Copyright (C) 2011,2013-2015 - TortoiseGit
 // Copyright (C) 2007-2008,2010,2012 - TortoiseSVN
 
 // This program is free software; you can redistribute it and/or
@@ -109,13 +109,13 @@ bool DropCopyAddCommand::Execute()
 								lastRepo.Empty();
 						}
 						int pos = -1;
-						if ((pos = filepath.Find(L"\\" + g_GitAdminDir.GetAdminDirName())) >= 0)
-							isRepo = (pos == filepath.GetLength() - g_GitAdminDir.GetAdminDirName().GetLength() - 1);
+						if ((pos = filepath.Find(L"\\" + GitAdminDir::GetAdminDirName())) >= 0)
+							isRepo = (pos == filepath.GetLength() - GitAdminDir::GetAdminDirName().GetLength() - 1);
 						else
 							isRepo = false;
 						if (isRepo)
 						{
-							lastRepo = filepath.Mid(0, filepath.GetLength() - g_GitAdminDir.GetAdminDirName().GetLength());
+							lastRepo = filepath.Mid(0, filepath.GetLength() - GitAdminDir::GetAdminDirName().GetLength());
 							CString msg;
 							if (!isDir)
 								msg.Format(IDS_PROC_COPY_SUBMODULE, lastRepo);

--- a/src/TortoiseProc/Commands/FetchCommand.cpp
+++ b/src/TortoiseProc/Commands/FetchCommand.cpp
@@ -1,6 +1,6 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
-// Copyright (C) 2008-2013 - TortoiseGit
+// Copyright (C) 2008-2013, 2015 - TortoiseGit
 
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -23,7 +23,7 @@
 
 bool FetchCommand::Execute()
 {
-	if (!GitAdminDir().HasAdminDir(g_Git.m_CurrentDir) && !GitAdminDir().IsBareRepo(g_Git.m_CurrentDir)) {
+	if (!GitAdminDir::HasAdminDir(g_Git.m_CurrentDir) && !GitAdminDir::IsBareRepo(g_Git.m_CurrentDir)) {
 		CMessageBox::Show(hwndExplorer, IDS_NOWORKINGCOPY, IDS_APPNAME, MB_ICONERROR);
 		return false;
 	}

--- a/src/TortoiseProc/Commands/FetchCommand.cpp
+++ b/src/TortoiseProc/Commands/FetchCommand.cpp
@@ -23,7 +23,8 @@
 
 bool FetchCommand::Execute()
 {
-	if (!GitAdminDir::HasAdminDir(g_Git.m_CurrentDir) && !GitAdminDir::IsBareRepo(g_Git.m_CurrentDir)) {
+	if (!GitAdminDir::IsWorkingTreeOrBareRepo(g_Git.m_CurrentDir))
+	{
 		CMessageBox::Show(hwndExplorer, IDS_NOWORKINGCOPY, IDS_APPNAME, MB_ICONERROR);
 		return false;
 	}

--- a/src/TortoiseProc/Commands/LogCommand.cpp
+++ b/src/TortoiseProc/Commands/LogCommand.cpp
@@ -25,7 +25,8 @@
 
 bool LogCommand::Execute()
 {
-	if (!GitAdminDir::HasAdminDir(g_Git.m_CurrentDir) && !GitAdminDir::IsBareRepo(g_Git.m_CurrentDir)) {
+	if (!GitAdminDir::IsWorkingTreeOrBareRepo(g_Git.m_CurrentDir))
+	{
 		CMessageBox::Show(hwndExplorer, IDS_NOWORKINGCOPY, IDS_APPNAME, MB_ICONERROR);
 		return false;
 	}

--- a/src/TortoiseProc/Commands/LogCommand.cpp
+++ b/src/TortoiseProc/Commands/LogCommand.cpp
@@ -1,7 +1,7 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
 // Copyright (C) 2007-2008,2011 - TortoiseSVN
-// Copyright (C) 2008-2014 - TortoiseGit
+// Copyright (C) 2008-2015 - TortoiseGit
 
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -25,7 +25,7 @@
 
 bool LogCommand::Execute()
 {
-	if (!GitAdminDir().HasAdminDir(g_Git.m_CurrentDir) && !g_GitAdminDir.IsBareRepo(g_Git.m_CurrentDir)) {
+	if (!GitAdminDir::HasAdminDir(g_Git.m_CurrentDir) && !GitAdminDir::IsBareRepo(g_Git.m_CurrentDir)) {
 		CMessageBox::Show(hwndExplorer, IDS_NOWORKINGCOPY, IDS_APPNAME, MB_ICONERROR);
 		return false;
 	}

--- a/src/TortoiseProc/Commands/PullCommand.cpp
+++ b/src/TortoiseProc/Commands/PullCommand.cpp
@@ -1,6 +1,6 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
-// Copyright (C) 2008-2013 - TortoiseGit
+// Copyright (C) 2008-2013, 2015 - TortoiseGit
 // Copyright (C) 2007-2008 - TortoiseSVN
 
 // This program is free software; you can redistribute it and/or
@@ -24,7 +24,8 @@
 
 bool PullCommand::Execute()
 {
-	if (!GitAdminDir().HasAdminDir(g_Git.m_CurrentDir)) {
+	if (!GitAdminDir::HasAdminDir(g_Git.m_CurrentDir))
+	{
 		CMessageBox::Show(hwndExplorer, IDS_NOWORKINGCOPY, IDS_APPNAME, MB_ICONERROR);
 		return false;
 	}

--- a/src/TortoiseProc/Commands/PushCommand.cpp
+++ b/src/TortoiseProc/Commands/PushCommand.cpp
@@ -31,7 +31,8 @@
 
 bool PushCommand::Execute()
 {
-	if (!GitAdminDir::HasAdminDir(g_Git.m_CurrentDir) && !GitAdminDir::IsBareRepo(g_Git.m_CurrentDir)) {
+	if (!GitAdminDir::IsWorkingTreeOrBareRepo(g_Git.m_CurrentDir))
+	{
 		CMessageBox::Show(hwndExplorer, IDS_NOWORKINGCOPY, IDS_APPNAME, MB_ICONERROR);
 		return false;
 	}

--- a/src/TortoiseProc/Commands/PushCommand.cpp
+++ b/src/TortoiseProc/Commands/PushCommand.cpp
@@ -1,7 +1,7 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
 // Copyright (C) 2007-2008 - TortoiseSVN
-// Copyright (C) 2008-2013 - TortoiseGit
+// Copyright (C) 2008-2013, 2015 - TortoiseGit
 
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -31,7 +31,7 @@
 
 bool PushCommand::Execute()
 {
-	if (!GitAdminDir().HasAdminDir(g_Git.m_CurrentDir) && !GitAdminDir().IsBareRepo(g_Git.m_CurrentDir)) {
+	if (!GitAdminDir::HasAdminDir(g_Git.m_CurrentDir) && !GitAdminDir::IsBareRepo(g_Git.m_CurrentDir)) {
 		CMessageBox::Show(hwndExplorer, IDS_NOWORKINGCOPY, IDS_APPNAME, MB_ICONERROR);
 		return false;
 	}

--- a/src/TortoiseProc/Commands/RepoStatusCommand.cpp
+++ b/src/TortoiseProc/Commands/RepoStatusCommand.cpp
@@ -1,6 +1,6 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
-// Copyright (C) 2012 - TortoiseGit
+// Copyright (C) 2012, 2015 - TortoiseGit
 // Copyright (C) 2007 - TortoiseSVN
 
 // This program is free software; you can redistribute it and/or
@@ -24,7 +24,8 @@
 
 bool RepoStatusCommand::Execute()
 {
-	if (!GitAdminDir().HasAdminDir(g_Git.m_CurrentDir)) {
+	if (!GitAdminDir::HasAdminDir(g_Git.m_CurrentDir))
+	{
 		CMessageBox::Show(hwndExplorer, IDS_NOWORKINGCOPY, IDS_APPNAME, MB_ICONERROR);
 		return false;
 	}

--- a/src/TortoiseProc/Commands/RepositoryBrowserCommand.cpp
+++ b/src/TortoiseProc/Commands/RepositoryBrowserCommand.cpp
@@ -1,6 +1,6 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
-// Copyright (C) 2012 - TortoiseGit
+// Copyright (C) 2012, 2015 - TortoiseGit
 
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -23,7 +23,7 @@
 
 bool RepositoryBrowserCommand::Execute()
 {
-	if (!GitAdminDir().HasAdminDir(g_Git.m_CurrentDir) && !GitAdminDir().IsBareRepo(g_Git.m_CurrentDir)) {
+	if (!GitAdminDir::HasAdminDir(g_Git.m_CurrentDir) && !GitAdminDir::IsBareRepo(g_Git.m_CurrentDir)) {
 		CMessageBox::Show(hwndExplorer, IDS_NOWORKINGCOPY, IDS_APPNAME, MB_ICONERROR);
 		return false;
 	}

--- a/src/TortoiseProc/Commands/RepositoryBrowserCommand.cpp
+++ b/src/TortoiseProc/Commands/RepositoryBrowserCommand.cpp
@@ -23,7 +23,8 @@
 
 bool RepositoryBrowserCommand::Execute()
 {
-	if (!GitAdminDir::HasAdminDir(g_Git.m_CurrentDir) && !GitAdminDir::IsBareRepo(g_Git.m_CurrentDir)) {
+	if (!GitAdminDir::IsWorkingTreeOrBareRepo(g_Git.m_CurrentDir))
+	{
 		CMessageBox::Show(hwndExplorer, IDS_NOWORKINGCOPY, IDS_APPNAME, MB_ICONERROR);
 		return false;
 	}

--- a/src/TortoiseProc/Commands/SVNIgnoreCommand.cpp
+++ b/src/TortoiseProc/Commands/SVNIgnoreCommand.cpp
@@ -1,6 +1,6 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
-// Copyright (C) 2007-2008,2012,2014 - TortoiseGit
+// Copyright (C) 2007-2008,2012,2014-2015 - TortoiseGit
 
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -40,7 +40,7 @@ bool SVNIgnoreCommand::Execute()
 			{
 				progress.m_GitCmd = _T("git.exe svn show-ignore");
 				CString dotGitPath;
-				g_GitAdminDir.GetAdminDirPath(g_Git.m_CurrentDir, dotGitPath);
+				GitAdminDir::GetAdminDirPath(g_Git.m_CurrentDir, dotGitPath);
 				progress.m_LogFile = dotGitPath + _T("info\\exclude");
 				progress.m_bShowCommand = false;
 				progress.m_PreText = _T("git.exe svn show-ignore > ") + progress.m_LogFile;

--- a/src/TortoiseProc/Commands/SubmoduleCommand.cpp
+++ b/src/TortoiseProc/Commands/SubmoduleCommand.cpp
@@ -1,6 +1,6 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
-// Copyright (C) 2008-2009,2012-2014 - TortoiseGit
+// Copyright (C) 2008-2009,2012-2015 - TortoiseGit
 
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -99,7 +99,7 @@ bool SubmoduleUpdateCommand::Execute()
 			bkpath = bkpath.Left(start);
 	}
 
-	CString super = g_GitAdminDir.GetSuperProjectRoot(bkpath);
+	CString super = GitAdminDir::GetSuperProjectRoot(bkpath);
 	if (super.IsEmpty())
 	{
 		CMessageBox::Show(NULL,IDS_ERR_NOTFOUND_SUPER_PRJECT,IDS_APPNAME,MB_OK|MB_ICONERROR);
@@ -178,7 +178,7 @@ bool SubmoduleCommand::Execute(CString cmd,  CString arg)
 			bkpath=bkpath.Left(start);
 	}
 
-	CString super=g_GitAdminDir.GetSuperProjectRoot( bkpath );
+	CString super = GitAdminDir::GetSuperProjectRoot(bkpath);
 	if(super.IsEmpty())
 	{
 		CMessageBox::Show(NULL,IDS_ERR_NOTFOUND_SUPER_PRJECT,IDS_APPNAME,MB_OK|MB_ICONERROR);

--- a/src/TortoiseProc/Commands/SyncCommand.cpp
+++ b/src/TortoiseProc/Commands/SyncCommand.cpp
@@ -1,7 +1,7 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
 // Copyright (C) 2008-2009 - TortoiseSVN
-// Copyright (C) 2008-2012 - TortoiseGit
+// Copyright (C) 2008-2012, 2015 - TortoiseGit
 
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -28,7 +28,7 @@
 
 bool SyncCommand::Execute()
 {
-	if (!GitAdminDir().HasAdminDir(g_Git.m_CurrentDir) && !GitAdminDir().IsBareRepo(g_Git.m_CurrentDir)) {
+	if (!GitAdminDir::HasAdminDir(g_Git.m_CurrentDir) && !GitAdminDir::IsBareRepo(g_Git.m_CurrentDir)) {
 		CMessageBox::Show(hwndExplorer, IDS_NOWORKINGCOPY, IDS_APPNAME, MB_ICONERROR);
 		return false;
 	}

--- a/src/TortoiseProc/Commands/SyncCommand.cpp
+++ b/src/TortoiseProc/Commands/SyncCommand.cpp
@@ -28,7 +28,8 @@
 
 bool SyncCommand::Execute()
 {
-	if (!GitAdminDir::HasAdminDir(g_Git.m_CurrentDir) && !GitAdminDir::IsBareRepo(g_Git.m_CurrentDir)) {
+	if (!GitAdminDir::IsWorkingTreeOrBareRepo(g_Git.m_CurrentDir))
+	{
 		CMessageBox::Show(hwndExplorer, IDS_NOWORKINGCOPY, IDS_APPNAME, MB_ICONERROR);
 		return false;
 	}

--- a/src/TortoiseProc/CommitDlg.cpp
+++ b/src/TortoiseProc/CommitDlg.cpp
@@ -1,7 +1,7 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
 // Copyright (C) 2003-2013 - TortoiseSVN
-// Copyright (C) 2008-2014 - TortoiseGit
+// Copyright (C) 2008-2015 - TortoiseGit
 
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -192,7 +192,7 @@ BOOL CCommitDlg::OnInitDialog()
 			GetCommitTemplate(m_sLogMessage);
 
 		CString dotGitPath;
-		g_GitAdminDir.GetAdminDirPath(g_Git.m_CurrentDir, dotGitPath);
+		GitAdminDir::GetAdminDirPath(g_Git.m_CurrentDir, dotGitPath);
 		bool loadedMsg = !CGit::LoadTextFile(dotGitPath + _T("MERGE_MSG"), m_sLogMessage);
 		loadedMsg = loadedMsg && !CGit::LoadTextFile(dotGitPath + _T("SQUASH_MSG"), m_sLogMessage);
 	}
@@ -1167,7 +1167,7 @@ UINT CCommitDlg::StatusThread()
 	}
 
 	CString dotGitPath;
-	g_GitAdminDir.GetAdminDirPath(g_Git.m_CurrentDir, dotGitPath);
+	GitAdminDir::GetAdminDirPath(g_Git.m_CurrentDir, dotGitPath);
 	if (PathFileExists(dotGitPath + _T("CHERRY_PICK_HEAD")))
 	{
 		GetDlgItem(IDC_COMMIT_AMENDDIFF)->ShowWindow(SW_HIDE);

--- a/src/TortoiseProc/CreateBranchTagDlg.cpp
+++ b/src/TortoiseProc/CreateBranchTagDlg.cpp
@@ -1,6 +1,6 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
-// Copyright (C) 2008-2014 - TortoiseGit
+// Copyright (C) 2008-2015 - TortoiseGit
 
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -126,7 +126,7 @@ BOOL CCreateBranchTagDlg::OnInitDialog()
 	CAppUtils::SetWindowTitle(m_hWnd, g_Git.m_CurrentDir, sWindowTitle);
 
 	// show the switch checkbox if we are a create branch dialog
-	this->GetDlgItem(IDC_CHECK_SWITCH)->ShowWindow( !m_bIsTag && !g_GitAdminDir.IsBareRepo(g_Git.m_CurrentDir));
+	this->GetDlgItem(IDC_CHECK_SWITCH)->ShowWindow(!m_bIsTag && !GitAdminDir::IsBareRepo(g_Git.m_CurrentDir));
 	CWnd* pHead = GetDlgItem(IDC_RADIO_HEAD);
 	CString HeadText;
 	pHead->GetWindowText( HeadText );

--- a/src/TortoiseProc/FileDiffDlg.cpp
+++ b/src/TortoiseProc/FileDiffDlg.cpp
@@ -1,6 +1,6 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
-// Copyright (C) 2008-2014 - TortoiseGit
+// Copyright (C) 2008-2015 - TortoiseGit
 // Copyright (C) 2003-2008 - TortoiseSVN
 
 // This program is free software; you can redistribute it and/or
@@ -268,7 +268,7 @@ BOOL CFileDiffDlg::OnInitDialog()
 
 	EnableSaveRestore(_T("FileDiffDlg"));
 
-	m_bIsBare = GitAdminDir().IsBareRepo(g_Git.m_CurrentDir);
+	m_bIsBare = GitAdminDir::IsBareRepo(g_Git.m_CurrentDir);
 
 	if(this->m_strRev1.IsEmpty())
 		this->m_ctrRev1Edit.SetWindowText(this->m_rev1.m_CommitHash.ToString());

--- a/src/TortoiseProc/GitLogCache.cpp
+++ b/src/TortoiseProc/GitLogCache.cpp
@@ -1,6 +1,6 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
-// Copyright (C) 2008-2014 - TortoiseGit
+// Copyright (C) 2008-2015 - TortoiseGit
 
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -124,7 +124,7 @@ int CLogCache::FetchCacheIndex(CString GitDir)
 		return 0;
 
 	int ret=0;
-	if (!g_GitAdminDir.GetAdminDirPath(GitDir, m_GitDir))
+	if (!GitAdminDir::GetAdminDirPath(GitDir, m_GitDir))
 		return -1;
 
 	do

--- a/src/TortoiseProc/GitLogListBase.cpp
+++ b/src/TortoiseProc/GitLogListBase.cpp
@@ -381,7 +381,7 @@ void CGitLogListBase::InsertGitColumn()
 	SetExtendedStyle(exStyle);
 
 	// only load properties if we have a repository
-	if (GitAdminDir().HasAdminDir(g_Git.m_CurrentDir) || GitAdminDir().IsBareRepo(g_Git.m_CurrentDir))
+	if (GitAdminDir::HasAdminDir(g_Git.m_CurrentDir) || GitAdminDir::IsBareRepo(g_Git.m_CurrentDir))
 		UpdateProjectProperties();
 
 	static UINT normal[] =

--- a/src/TortoiseProc/GitLogListBase.cpp
+++ b/src/TortoiseProc/GitLogListBase.cpp
@@ -381,7 +381,7 @@ void CGitLogListBase::InsertGitColumn()
 	SetExtendedStyle(exStyle);
 
 	// only load properties if we have a repository
-	if (GitAdminDir::HasAdminDir(g_Git.m_CurrentDir) || GitAdminDir::IsBareRepo(g_Git.m_CurrentDir))
+	if (GitAdminDir::IsWorkingTreeOrBareRepo(g_Git.m_CurrentDir))
 		UpdateProjectProperties();
 
 	static UINT normal[] =

--- a/src/TortoiseProc/LogDlg.cpp
+++ b/src/TortoiseProc/LogDlg.cpp
@@ -278,7 +278,7 @@ BOOL CLogDlg::OnInitDialog()
 	m_LogList.DeleteAllItems();
 
 	m_LogList.m_Path=m_path;
-	m_LogList.m_hasWC = m_LogList.m_bShowWC = !g_GitAdminDir.IsBareRepo(g_Git.m_CurrentDir);
+	m_LogList.m_hasWC = m_LogList.m_bShowWC = !GitAdminDir::IsBareRepo(g_Git.m_CurrentDir);
 	m_LogList.InsertGitColumn();
 
 	if (m_bWholeProject)

--- a/src/TortoiseProc/ProjectProperties.cpp
+++ b/src/TortoiseProc/ProjectProperties.cpp
@@ -1,6 +1,6 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
-// Copyright (C) 2003-2011,2013-2014 - TortoiseGit
+// Copyright (C) 2003-2011,2013-2015 - TortoiseGit
 
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -49,10 +49,10 @@ int ProjectProperties::ReadProps()
 {
 	CAutoConfig gitconfig(true);
 	CString adminDirPath;
-	if (g_GitAdminDir.GetAdminDirPath(g_Git.m_CurrentDir, adminDirPath))
+	if (GitAdminDir::GetAdminDirPath(g_Git.m_CurrentDir, adminDirPath))
 		git_config_add_file_ondisk(gitconfig, CGit::GetGitPathStringA(adminDirPath + L"config"), GIT_CONFIG_LEVEL_APP, FALSE); // this needs to have the highest priority in order to override .tgitconfig settings
 
-	if (!g_GitAdminDir.IsBareRepo(g_Git.m_CurrentDir))
+	if (!GitAdminDir::IsBareRepo(g_Git.m_CurrentDir))
 		git_config_add_file_ondisk(gitconfig, CGit::GetGitPathStringA(g_Git.CombinePath(L".tgitconfig")), GIT_CONFIG_LEVEL_LOCAL, FALSE); // this needs to have the second highest priority
 	else
 	{

--- a/src/TortoiseProc/PullFetchDlg.cpp
+++ b/src/TortoiseProc/PullFetchDlg.cpp
@@ -1,6 +1,6 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
-// Copyright (C) 2008-2014 - TortoiseGit
+// Copyright (C) 2008-2015 - TortoiseGit
 
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -204,7 +204,7 @@ BOOL CPullFetchDlg::OnInitDialog()
 		this->GetDlgItem(IDC_CHECK_NOCOMMIT)->EnableWindow(FALSE);
 	}
 
-	if (g_GitAdminDir.IsBareRepo(g_Git.m_CurrentDir))
+	if (GitAdminDir::IsBareRepo(g_Git.m_CurrentDir))
 		this->GetDlgItem(IDC_CHECK_REBASE)->EnableWindow(FALSE);
 
 	if (repo && git_repository_is_shallow(repo))

--- a/src/TortoiseProc/RebaseDlg.cpp
+++ b/src/TortoiseProc/RebaseDlg.cpp
@@ -1967,7 +1967,7 @@ LRESULT CRebaseDlg::OnRebaseUpdateUI(WPARAM,LPARAM)
 		if (m_IsCherryPick)
 		{
 			CString dotGitPath;
-			g_GitAdminDir.GetAdminDirPath(g_Git.m_CurrentDir, dotGitPath);
+			GitAdminDir::GetAdminDirPath(g_Git.m_CurrentDir, dotGitPath);
 			// vanilla git also re-uses MERGE_MSG on conflict (listing all conflicted files)
 			// and it's also needed for cherry-pick in order to get cherry-picked-from included on conflicts
 			CGit::LoadTextFile(dotGitPath + _T("MERGE_MSG"), logMessage);

--- a/src/TortoiseProc/RefLogDlg.cpp
+++ b/src/TortoiseProc/RefLogDlg.cpp
@@ -1,6 +1,6 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
-// Copyright (C) 2009-2014 - TortoiseGit
+// Copyright (C) 2009-2015 - TortoiseGit
 
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -89,7 +89,7 @@ BOOL CRefLogDlg::OnInitDialog()
 
 	m_ChooseRef.SetMaxHistoryItems(0x7FFFFFFF);
 
-	m_RefList.m_hasWC = !g_GitAdminDir.IsBareRepo(g_Git.m_CurrentDir);
+	m_RefList.m_hasWC = !GitAdminDir::IsBareRepo(g_Git.m_CurrentDir);
 
 	this->m_RefList.InsertRefLogColumn();
 

--- a/src/TortoiseProc/RepositoryBrowser.cpp
+++ b/src/TortoiseProc/RepositoryBrowser.cpp
@@ -1,6 +1,6 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
-// Copyright (C) 2009-2014 - TortoiseGit
+// Copyright (C) 2009-2015 - TortoiseGit
 // Copyright (C) 2003-2013 - TortoiseSVN
 
 // This program is free software; you can redistribute it and/or
@@ -252,7 +252,7 @@ BOOL CRepositoryBrowser::OnInitDialog()
 	GetWindowText(sWindowTitle);
 	CAppUtils::SetWindowTitle(m_hWnd, g_Git.m_CurrentDir, sWindowTitle);
 
-	m_bHasWC = !g_GitAdminDir.IsBareRepo(g_Git.m_CurrentDir);
+	m_bHasWC = !GitAdminDir::IsBareRepo(g_Git.m_CurrentDir);
 
 	Refresh();
 
@@ -1198,7 +1198,7 @@ void CRepositoryBrowser::OpenFile(const CString path, eOpenType mode, bool isSub
 
 	if (isSubmodule)
 	{
-		if (mode == OPEN && !g_GitAdminDir.IsBareRepo(g_Git.m_CurrentDir))
+		if (mode == OPEN && !GitAdminDir::IsBareRepo(g_Git.m_CurrentDir))
 		{
 			CTGitPath subPath = CTGitPath(g_Git.m_CurrentDir);
 			subPath.AppendPathString(gitPath.GetWinPathString());

--- a/src/TortoiseProc/ResetDlg.cpp
+++ b/src/TortoiseProc/ResetDlg.cpp
@@ -1,6 +1,6 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
-// Copyright (C) 2008-2014 - TortoiseGit
+// Copyright (C) 2008-2015 - TortoiseGit
 
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -85,7 +85,7 @@ BOOL CResetDlg::OnInitDialog()
 	resetTo.Format(IDS_PROC_RESETBRANCH, currentBranch);
 	GetDlgItem(IDC_GROUP_BASEON)->SetWindowTextW(resetTo);
 
-	if (g_GitAdminDir.IsBareRepo(g_Git.m_CurrentDir))
+	if (GitAdminDir::IsBareRepo(g_Git.m_CurrentDir))
 	{
 		m_ResetType = 0;
 		DialogEnableWindow(IDC_RADIO_RESET_MIXED, FALSE);

--- a/src/TortoiseProc/Settings/GitSettings.h
+++ b/src/TortoiseProc/Settings/GitSettings.h
@@ -1,6 +1,6 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
-// Copyright (C) 2013-2014 - TortoiseGit
+// Copyright (C) 2013-2015 - TortoiseGit
 
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -56,9 +56,9 @@ protected:
 		}
 
 		CString str = g_Git.m_CurrentDir;
-		m_bIsBareRepo = g_GitAdminDir.IsBareRepo(str);
+		m_bIsBareRepo = GitAdminDir::IsBareRepo(str);
 		CString proj;
-		if (g_GitAdminDir.HasAdminDir(str, &proj) || m_bIsBareRepo)
+		if (GitAdminDir::HasAdminDir(str, &proj) || m_bIsBareRepo)
 		{
 			CString title;
 			page->GetWindowText(title);

--- a/src/TortoiseProc/Settings/SettingGitConfig.cpp
+++ b/src/TortoiseProc/Settings/SettingGitConfig.cpp
@@ -1,6 +1,6 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
-// Copyright (C) 2008-2014 - TortoiseGit
+// Copyright (C) 2008-2015 - TortoiseGit
 
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -283,7 +283,7 @@ void CSettingGitConfig::OnBnClickedEditlocalgitconfig()
 void CSettingGitConfig::OnBnClickedEdittgitconfig()
 {
 	// use alternative editor because of LineEndings
-	if (g_GitAdminDir.IsBareRepo(g_Git.m_CurrentDir))
+	if (GitAdminDir::IsBareRepo(g_Git.m_CurrentDir))
 	{
 		CString tmpFile = GetTempFile();
 		CTGitPath path(_T(".tgitconfig"));

--- a/src/TortoiseProc/Settings/SettingGitCredential.cpp
+++ b/src/TortoiseProc/Settings/SettingGitCredential.cpp
@@ -1,6 +1,6 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
-// Copyright (C) 2013-2014 - TortoiseGit
+// Copyright (C) 2013-2015 - TortoiseGit
 
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -171,7 +171,7 @@ BOOL CSettingGitCredential::OnInitDialog()
 
 	AdjustControlSize(IDC_CHECK_USEHTTPPATH);
 
-	bool hasLocal = g_GitAdminDir.HasAdminDir(g_Git.m_CurrentDir);
+	bool hasLocal = GitAdminDir::HasAdminDir(g_Git.m_CurrentDir);
 
 	m_ctrlUrlList.ResetContent();
 

--- a/src/TortoiseProc/Settings/Settings.cpp
+++ b/src/TortoiseProc/Settings/Settings.cpp
@@ -123,7 +123,7 @@ void CSettings::AddPropPages()
 	AddPage(m_pSavedPage);
 
 	CString repo = g_Git.m_CurrentDir;
-	bool hasLocalRepo = GitAdminDir::HasAdminDir(repo) || GitAdminDir::IsBareRepo(repo);
+	bool hasLocalRepo = GitAdminDir::IsWorkingTreeOrBareRepo(repo);
 	if (hasLocalRepo)
 	{
 		AddPage(m_pGitRemote);
@@ -292,7 +292,7 @@ BOOL CSettings::OnInitDialog()
 
 	SetIcon(m_hIcon, TRUE);			// Set big icon
 	SetIcon(m_hIcon, FALSE);		// Set small icon
-	if (GitAdminDir::HasAdminDir(g_Git.m_CurrentDir) || GitAdminDir::IsBareRepo(g_Git.m_CurrentDir))
+	if (GitAdminDir::IsWorkingTreeOrBareRepo(g_Git.m_CurrentDir))
 	{
 		CString title;
 		GetWindowText(title);
@@ -394,7 +394,7 @@ BOOL CSettings::OnInitDialog()
 	{
 		this->SetActivePage(this->m_pUDiffPage);
 	}
-	else if (GitAdminDir::HasAdminDir(g_Git.m_CurrentDir) || GitAdminDir::IsBareRepo(g_Git.m_CurrentDir))
+	else if (GitAdminDir::IsWorkingTreeOrBareRepo(g_Git.m_CurrentDir))
 	{
 		this->SetActivePage(this->m_pGitConfig);
 	}

--- a/src/TortoiseProc/Settings/Settings.cpp
+++ b/src/TortoiseProc/Settings/Settings.cpp
@@ -1,6 +1,6 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
-// Copyright (C) 2008-2014 - TortoiseGit
+// Copyright (C) 2008-2015 - TortoiseGit
 // Copyright (C) 2003-2008 - TortoiseSVN
 
 // This program is free software; you can redistribute it and/or
@@ -123,7 +123,7 @@ void CSettings::AddPropPages()
 	AddPage(m_pSavedPage);
 
 	CString repo = g_Git.m_CurrentDir;
-	bool hasLocalRepo = g_GitAdminDir.HasAdminDir(repo) || g_GitAdminDir.IsBareRepo(repo);
+	bool hasLocalRepo = GitAdminDir::HasAdminDir(repo) || GitAdminDir::IsBareRepo(repo);
 	if (hasLocalRepo)
 	{
 		AddPage(m_pGitRemote);
@@ -292,7 +292,7 @@ BOOL CSettings::OnInitDialog()
 
 	SetIcon(m_hIcon, TRUE);			// Set big icon
 	SetIcon(m_hIcon, FALSE);		// Set small icon
-	if (g_GitAdminDir.HasAdminDir(g_Git.m_CurrentDir) || g_GitAdminDir.IsBareRepo(g_Git.m_CurrentDir))
+	if (GitAdminDir::HasAdminDir(g_Git.m_CurrentDir) || GitAdminDir::IsBareRepo(g_Git.m_CurrentDir))
 	{
 		CString title;
 		GetWindowText(title);
@@ -394,7 +394,7 @@ BOOL CSettings::OnInitDialog()
 	{
 		this->SetActivePage(this->m_pUDiffPage);
 	}
-	else if (g_GitAdminDir.HasAdminDir(g_Git.m_CurrentDir) || g_GitAdminDir.IsBareRepo(g_Git.m_CurrentDir))
+	else if (GitAdminDir::HasAdminDir(g_Git.m_CurrentDir) || GitAdminDir::IsBareRepo(g_Git.m_CurrentDir))
 	{
 		this->SetActivePage(this->m_pGitConfig);
 	}

--- a/src/TortoiseProc/TortoiseProc.cpp
+++ b/src/TortoiseProc/TortoiseProc.cpp
@@ -436,7 +436,7 @@ BOOL CTortoiseProcApp::InitInstance()
 		case 4:
 			{
 				CString wcroot;
-				if (g_GitAdminDir.HasAdminDir(g_Git.m_CurrentDir, true, &wcroot))
+				if (GitAdminDir::HasAdminDir(g_Git.m_CurrentDir, true, &wcroot))
 				{
 					git_oid oid;
 					CStringA wcRootA(wcroot + CPathUtils::GetAppDirectory());

--- a/src/TortoiseShell/ContextMenu.cpp
+++ b/src/TortoiseShell/ContextMenu.cpp
@@ -1,7 +1,7 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
 // Copyright (C) 2003-2012, 2014-2015 - TortoiseSVN
-// Copyright (C) 2008-2014 - TortoiseGit
+// Copyright (C) 2008-2015 - TortoiseGit
 
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -232,7 +232,7 @@ STDMETHODIMP CShellExt::Initialize_Wrap(LPCITEMIDLIST pIDFolder,
 					if ((str.empty() == false)&&(g_ShellCache.IsContextPathAllowed(str.c_str())))
 					{
 						//check if our menu is requested for a git admin directory
-						if (g_GitAdminDir.IsAdminDirPath(str.c_str()))
+						if (GitAdminDir::IsAdminDirPath(str.c_str()))
 							continue;
 
 						files_.push_back(str);
@@ -347,7 +347,7 @@ STDMETHODIMP CShellExt::Initialize_Wrap(LPCITEMIDLIST pIDFolder,
 				if (g_ShellCache.HasGITAdminDir(child.toString().c_str(), FALSE))
 					itemStates |= ITEMIS_INVERSIONEDFOLDER;
 
-				if (g_GitAdminDir.IsBareRepo(child.toString().c_str()))
+				if (GitAdminDir::IsBareRepo(child.toString().c_str()))
 					itemStates = ITEMIS_BAREREPO;
 
 				GlobalUnlock(medium.hGlobal);
@@ -936,7 +936,7 @@ STDMETHODIMP CShellExt::QueryContextMenu_Wrap(HMENU hMenu,
 	}
 
 	//check if our menu is requested for a git admin directory
-	if (g_GitAdminDir.IsAdminDirPath(folder_.c_str()))
+	if (GitAdminDir::IsAdminDirPath(folder_.c_str()))
 		return S_OK;
 
 	if (uFlags & CMF_EXTENDEDVERBS)
@@ -954,7 +954,7 @@ STDMETHODIMP CShellExt::QueryContextMenu_Wrap(HMENU hMenu,
 		// It would only show the standard menu items
 		// which are already shown for the lnk-file.
 		CString path = files_.front().c_str();
-		if ( !g_GitAdminDir.HasAdminDir(path) )
+		if (!GitAdminDir::HasAdminDir(path))
 		{
 			return S_OK;
 		}

--- a/src/TortoiseShell/ShellCache.h
+++ b/src/TortoiseShell/ShellCache.h
@@ -1,6 +1,6 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
-// Copyright (C) 2012-2014 - TortoiseGit
+// Copyright (C) 2012-2015 - TortoiseGit
 // Copyright (C) 2003-2008 - Stefan Kueng
 
 // This program is free software; you can redistribute it and/or
@@ -494,7 +494,7 @@ public:
 			}
 		}
 		CString sProjectRoot;
-		BOOL hasAdminDir = g_GitAdminDir.HasAdminDir(buf.get(), true, &sProjectRoot);
+		BOOL hasAdminDir = GitAdminDir::HasAdminDir(buf.get(), true, &sProjectRoot);
 		admindirticker = GetTickCount();
 		Locker lock(m_critSec);
 

--- a/src/TortoiseShell/ShellExt.cpp
+++ b/src/TortoiseShell/ShellExt.cpp
@@ -1,6 +1,6 @@
 // TortoiseGit - a Windows shell extension for easy version control
 
-// Copyright (C) 2011-2014 - TortoiseGit
+// Copyright (C) 2011-2015 - TortoiseGit
 // Copyright (C) 2003-2013 - TortoiseSVN
 
 // This program is free software; you can redistribute it and/or
@@ -292,7 +292,7 @@ UINT __stdcall CShellExt::CopyCallback_Wrap(HWND /*hWnd*/, UINT wFunc, UINT /*wF
 		if (pszSrcFile && pszSrcFile[0])
 		{
 			CString topDir;
-			if (g_GitAdminDir.HasAdminDir(pszSrcFile, &topDir))
+			if (GitAdminDir::HasAdminDir(pszSrcFile, &topDir))
 				m_CachedStatus.m_GitStatus.ReleasePath(topDir);
 			m_remoteCacheLink.ReleaseLockForPath(CTGitPath(pszSrcFile));
 		}


### PR DESCRIPTION
Do we need a GitdminDir object (as TSVN has, for the ASP.NET hack) or can we use static methods?

I think we can use static methods, do I overlook something?