### PR TITLE
Add UTF8-BOM

### DIFF
--- a/test/UnitTests/TortoiseGitBlameDataTest.cpp
+++ b/test/UnitTests/TortoiseGitBlameDataTest.cpp
@@ -1,4 +1,4 @@
-// TortoiseGit - a Windows shell extension for easy version control
+ï»¿// TortoiseGit - a Windows shell extension for easy version control
 
 // Copyright (C) 2015 - TortoiseGit
 
@@ -461,7 +461,7 @@ TEST_F(CTortoiseGitBlameDataWithTestRepoFixture, ParseBlameOutput_UTF8_BOM)
 		EXPECT_STREQ(dates[i], data.GetDate(i));
 
 	data.UpdateEncoding(CP_UTF8);
-	const CString lines[] = { L"ä#äf34öööäß€9875oe", L"fgdjkglsfdg", L"öäöü45g", L"fdgi&§$%&hfdsgä", L"ä#äf34öööäß€9875oe", L"öäüpfgmfdg", L"€fgfdsg", L"45", L"äü" };
+	const CString lines[] = { L"Ã¤#Ã¤f34Ã¶Ã¶Ã¶Ã¤ÃŸÂ€9875oe", L"fgdjkglsfdg", L"Ã¶Ã¤Ã¶Ã¼45g", L"fdgi&Â§$%&hfdsgÃ¤", L"Ã¤#Ã¤f34Ã¶Ã¶Ã¶Ã¤ÃŸÂ€9875oe", L"Ã¶Ã¤Ã¼pfgmfdg", L"Â€fgfdsg", L"45", L"Ã¤Ã¼" };
 	for (int i = 0; i < 9; ++i)
 		EXPECT_STREQ(lines[i] + _T('\r'), CUnicodeUtils::GetUnicode(data.GetUtf8Line(i)));
 


### PR DESCRIPTION
Can't build the source code when checkout ```tests``` branch.
See:
![err](https://cloud.githubusercontent.com/assets/5831804/6589228/a864d70e-c7d7-11e4-9929-1c0079121bdd.png)

![text](https://cloud.githubusercontent.com/assets/5831804/6589230/ad732eda-c7d7-11e4-8654-8737f7982bd3.png)

So, **add UTF8-BOM**
![utf8](https://cloud.githubusercontent.com/assets/5831804/6589070/918d55a8-c7d5-11e4-970b-0e6817bb0c1a.png)

No signed-off-by, because wish to squash this commit into the commit ```WIP TGitBlame``` (fbf2809607fb62ae677dd841d13c042d179500f0) which is marked as *WIP*. :)


@csware 
BTW, could you create a mirror repo of ```gtest``` and re-direct the submodule to it?
Seems google have a policy that rejecting the accessing if access their source so often.
