### PR TITLE
Increase default item limit of `CHistoryCombo`

### DIFF
--- a/src/Utils/MiscUI/HistoryCombo.cpp
+++ b/src/Utils/MiscUI/HistoryCombo.cpp
@@ -25,7 +25,7 @@
 #include "../SysImageList.h"
 #endif
 
-#define MAX_HISTORY_ITEMS 25
+#define MAX_HISTORY_ITEMS 50
 
 int CHistoryCombo::m_nGitIconIndex = 0;
 


### PR DESCRIPTION
... to 50 items. I have a project with more than 25 remotes, so I wasn't finding the remote in the Remote drop down in the Push dialog.
