### PR TITLE
Not all remotes showing in Push dialog

### DIFF
--- a/src/TortoiseProc/PullFetchDlg.cpp
+++ b/src/TortoiseProc/PullFetchDlg.cpp
@@ -182,6 +182,7 @@ BOOL CPullFetchDlg::OnInitDialog()
 
 	CheckRadioButton(IDC_REMOTE_RD,IDC_OTHER_RD,IDC_REMOTE_RD);
 	m_Remote.EnableWindow(TRUE);
+	m_Remote.SetMaxHistoryItems(0x7FFFFFFF);
 	m_Other.EnableWindow(FALSE);
 	if(!m_IsPull)
 	{

--- a/src/TortoiseProc/PushDlg.cpp
+++ b/src/TortoiseProc/PushDlg.cpp
@@ -222,6 +222,7 @@ void CPushDlg::Refresh()
 
 	STRING_VECTOR list;
 	m_Remote.Reset();
+	m_Remote.SetMaxHistoryItems(0x7FFFFFFF);
 
 	if(!g_Git.GetRemoteList(list))
 	{

--- a/src/TortoiseProc/SyncDlg.cpp
+++ b/src/TortoiseProc/SyncDlg.cpp
@@ -925,6 +925,7 @@ BOOL CSyncDlg::OnInitDialog()
 
 	m_ctrlURL.SetCaseSensitive(TRUE);
 	m_ctrlURL.SetURLHistory(true);
+	m_ctrlURL.SetMaxHistoryItems(0x7FFFFFFF);
 	this->m_ctrlURL.LoadHistory(CString(_T("Software\\TortoiseGit\\History\\SyncURL\\"))+WorkingDir, _T("url"));
 
 	STRING_VECTOR list;


### PR DESCRIPTION
I have a project with more than 25 remotes, so I wasn't finding the remote in the Remote drop down in the Push dialog.