### PR TITLE
Sort remotes logically/case-insensitively

### DIFF
--- a/src/Git/Git.cpp
+++ b/src/Git/Git.cpp
@@ -1684,7 +1684,7 @@ int CGit::GetRemoteList(STRING_VECTOR &list)
 			list.push_back(CUnicodeUtils::GetUnicode(remote));
 		}
 
-		std::sort(list.begin(), list.end());
+		std::sort(list.begin(), list.end(), LogicalComparePredicate);
 
 		return 0;
 	}


### PR DESCRIPTION
The sort used for `CGit::GetRemoteList` was "human-unfriendly" and inconsistent with how it was displayed in the Settings-Remotes dialog pane also.

Signed-off-by: Duncan Smart <duncan.smart@gmail.com>