### PR TITLE
No need to create .git folder for bare repo testing fixture

### DIFF
--- a/test/UnitTests/RepositoryFixtures.h
+++ b/test/UnitTests/RepositoryFixtures.h
@@ -96,7 +96,7 @@ protected:
 			resourcesDir = CPathUtils::GetAppDirectory() + _T("\\..\\..\\..\\test\\UnitTests\\resources");
 			ASSERT_TRUE(PathIsDirectory(resourcesDir));
 		}
-		EXPECT_TRUE(CreateDirectory(m_Dir.GetTempDir() + _T("\\.git"), nullptr));
+		EXPECT_TRUE(CreateDirectory(m_Dir.GetTempDir() + prefix, nullptr));
 		CString repoDir = resourcesDir + _T("\\git-repo1");
 		CDirFileEnum finder(repoDir);
 		bool isDir;


### PR DESCRIPTION
The story:
1. **Refactor the fixture classes**, 
see [here](https://github.com/YueLinHo/TortoiseGit/commit/d3a99d6ef968df704f63942b5c3d1b9d722ca525) of my ```refactor``` branch. 
(that commit is picked from my experimental branch for issue 2431. 
(Used for preparing repo and submodule repo.)
2. ran tests and **found FETCHHEAD tests are failed**.
3. try to **fix it**, then created a PR #171 
4. After one day, I just find/realize why origin FETCHHEAD tests are passed, 
but failed in my ```refactor``` branch. 
(failed on [this line](https://github.com/TortoiseGit/TortoiseGit/blob/tests/test/UnitTests/GitTest.cpp#L506))

So, why that line pass test? => bare repo fixture also created a .git folder.
Now, I have this PR.

Suppose it should go with that [commit](https://github.com/TortoiseGit/TortoiseGit/commit/f907d9be655d7a950bb3efbac7c44b70d59e79c9) together.  (squash is possible?)

----
It is interesting:
A defect of testing code is captured by test after doing some refactor on other testing code.
is it some kind of "self-testing"? :-)