### PR TITLE
Fixed issue #2503: No more skip/edit the first commit in Rebase dialog

### DIFF
--- a/src/Changelog.txt
+++ b/src/Changelog.txt
@@ -9,6 +9,7 @@ Released: unreleased
 == Bug Fixes ==
  * Fixed issue #2495: "Show Reflog" dialog shows empty action for "push" entries
  * Fixed issue #2500: Amend with date reset causes an error with git 2.x
+ * Fixed issue #2503: No more skip/edit the first commit in Rebase dialog
 
 = Release 1.8.14.0 =
 Released: 2015-04-08

--- a/src/TortoiseProc/GitLogListAction.cpp
+++ b/src/TortoiseProc/GitLogListAction.cpp
@@ -1151,7 +1151,7 @@ void CGitLogList::SetSelectedRebaseAction(int action)
 	while(pos)
 	{
 		index = GetNextSelectedItem(pos);
-		if (((GitRevLoglist*)m_arShownList[index])->GetRebaseAction() & (LOGACTIONS_REBASE_CURRENT | LOGACTIONS_REBASE_DONE) || index == GetItemCount() - 1)
+		if (((GitRevLoglist*)m_arShownList[index])->GetRebaseAction() & (LOGACTIONS_REBASE_CURRENT | LOGACTIONS_REBASE_DONE) || (index == GetItemCount() - 1 && action == LOGACTIONS_REBASE_SQUASH))
 			continue;
 		((GitRevLoglist*)m_arShownList[index])->GetRebaseAction() = action;
 		CRect rect;


### PR DESCRIPTION
Regression of 7e5c0479277edf1c52029c9f85cb155ef9505556
cf [Issue 2503 on google code](https://code.google.com/p/tortoisegit/issues/detail?id=2503)

Tested it manually.