### PR TITLE
Fixed issue #2487: Show log dialog lose focus of "working dir changes" after content refresh

### DIFF
--- a/src/Changelog.txt
+++ b/src/Changelog.txt
@@ -15,6 +15,7 @@ Released: unreleased
  * Fixed issue #2509: Prompt for stash before rebase is not matched with pop stash after rebase
  * Fixed issue #2510: Non-correctly visualized settings dialog on modern high-DPI displays
  * Fixed issue #2514: diff uses wrong tool in case the filename matches a registered extension
+ * Fixed issue #2487: Show log dialog lose focus of "working dir changes" after content refresh
 
 = Release 1.8.14.0 =
 Released: 2015-04-08

--- a/src/TortoiseProc/GitLogListBase.cpp
+++ b/src/TortoiseProc/GitLogListBase.cpp
@@ -2856,6 +2856,9 @@ UINT CGitLogListBase::LogThread()
 
 	// store commit number of the last selected commit/line before the refresh or -1
 	int lastSelectedHashNItem = -1;
+	if (m_lastSelectedHash.IsEmpty())
+		lastSelectedHashNItem = 0;
+
 	int ret = 0;
 
 	bool shouldWalk = true;


### PR DESCRIPTION
Fixed [issue 2487](https://code.google.com/p/tortoisegit/issues/detail?id=2487)

^_^