### PR TITLE
LogDlg: Disable default limits when called with /rev

### DIFF
--- a/src/TortoiseProc/LogDlg.cpp
+++ b/src/TortoiseProc/LogDlg.cpp
@@ -221,7 +221,7 @@ void CLogDlg::SetParams(const CTGitPath& orgPath, const CTGitPath& path, CString
 
 	SetRange(range);
 
-	if (limitScale == CFilterData::SHOW_NO_LIMIT || (!range.IsEmpty() && m_LogList.m_Filter.m_NumberOfLogsScale != CFilterData::SHOW_LAST_N_COMMITS))
+	if (limitScale == CFilterData::SHOW_NO_LIMIT || (!range.IsEmpty() && m_LogList.m_Filter.m_NumberOfLogsScale != CFilterData::SHOW_LAST_N_COMMITS) || !hightlightRevision.IsEmpty())
 		m_LogList.m_Filter.m_NumberOfLogsScale = CFilterData::SHOW_NO_LIMIT;
 	if (limitScale >= CFilterData::SHOW_LAST_N_COMMITS && limit > 0)
 	{


### PR DESCRIPTION
As discussed on 296938235f2b50c6a9d9a58a2f4697b493839bf8

Integrating LogDlg into TGitBlame is not a good option as the dialog has many dependencies.

/cc @ch3cooli @YueLinHo 