### PR TITLE
Fixed issue #2546: Summary bar in TortoiseGitMerge missing

### DIFF
--- a/src/Changelog.txt
+++ b/src/Changelog.txt
@@ -36,6 +36,7 @@ Released: unreleased
                       Unchecked deleted/renamed files were not put into previous state in index after commit
  * Fixed issue #2537: TortoiseGitPlink will not connect to OpenSSH 6.9
                       Upgraded TortoiseGitPlink to version pre-0.65
+ * Fixed issue #2546: Summary bar in TortoiseGitMerge missing
 
 = Release 1.8.14.0 =
 Released: 2015-04-08

--- a/src/TortoiseMerge/MainFrm.cpp
+++ b/src/TortoiseMerge/MainFrm.cpp
@@ -350,6 +350,7 @@ int CMainFrame::OnCreate(LPCREATESTRUCT lpCreateStruct)
 		m_wndStatusBar.EnablePaneDoubleClick();
 	}
 
+	EnableLoadDockState(FALSE);
 	if (!m_wndLocatorBar.Create(this, IDD_DIFFLOCATOR,
 		CBRS_ALIGN_LEFT | CBRS_SIZE_FIXED, ID_VIEW_LOCATORBAR))
 	{


### PR DESCRIPTION
The [issue 2546](https://code.google.com/p/tortoisegit/issues/detail?id=2546)

> can we make MFC ignore them at all on loading (or even saving)?

@csware 
I have to say that is a good question. It guides me to find this solution.
As my teacher told me: ask right question, the answer is not far.
Thank @csware.

