### PR TITLE
Fix for Issue #2781

### DIFF
--- a/src/Changelog.txt
+++ b/src/Changelog.txt
@@ -10,6 +10,7 @@ Released: unreleased
  * Fixed issue #2767: The online help of Settings->Git->Remote should explain the "Push Default" checkbox
  * Fixed issue #2772: Comparing with added file might result in comparison with empty file
  * Fixed issue #2774: Pull dialog with Russian LangPack has three defficiencies
+ * Fixed issue #2781: SVNRebase Command does not respect closeonend 
 
 = Release 2.1.0 =
 Released: 2016-03-26

--- a/src/Changelog.txt
+++ b/src/Changelog.txt
@@ -3,6 +3,7 @@ Released: unreleased
 
 == Features ==
  * Updated libgit to 2.8.3
+ * Added stash parameter to SvnRebase command line to handle stash choice for unattended automation.
 
 == Bug Fixes ==
  * Fixed issue #2745: TortoiseGit 2.1 crashes on broken git config 

--- a/src/TortoiseProc/Commands/SVNRebaseCommand.cpp
+++ b/src/TortoiseProc/Commands/SVNRebaseCommand.cpp
@@ -98,6 +98,7 @@ bool SVNRebaseCommand::Execute()
 		return false;
 	}
 	CProgressDlg progress;
+	GitProgressAutoClose origAutoClose = progress.m_AutoClose;
 	progress.m_GitCmd=_T("git.exe svn fetch");
 	progress.m_AutoClose = AUTOCLOSE_IF_NO_ERRORS;
 
@@ -116,7 +117,9 @@ bool SVNRebaseCommand::Execute()
 	//everything updated
 	if(UpStreamNewHash==HeadHash)
 	{
-		MessageBox(hwndExplorer, g_Git.m_CurrentDir + _T("\r\n") + CString(MAKEINTRESOURCE(IDS_PROC_EVERYTHINGUPDATED)), _T("TortoiseGit"), MB_OK | MB_ICONQUESTION);
+		if (origAutoClose == AUTOCLOSE_NO)
+			MessageBox(hwndExplorer, g_Git.m_CurrentDir + _T("\r\n") + CString(MAKEINTRESOURCE(IDS_PROC_EVERYTHINGUPDATED)), _T("TortoiseGit"), MB_OK | MB_ICONQUESTION);
+
 		if(isStash)
 			askIfUserWantsToStashPop();
 
@@ -135,7 +138,9 @@ bool SVNRebaseCommand::Execute()
 			return false;
 		else
 		{
-			MessageBox(hwndExplorer, g_Git.m_CurrentDir + _T("\r\n") + CString(MAKEINTRESOURCE(IDS_PROC_FASTFORWARD)) + _T(":\n") + progressReset.m_LogText, _T("TortoiseGit"), MB_OK | MB_ICONQUESTION);
+			if (origAutoClose == AUTOCLOSE_NO)
+				MessageBox(hwndExplorer, g_Git.m_CurrentDir + _T("\r\n") + CString(MAKEINTRESOURCE(IDS_PROC_FASTFORWARD)) + _T(":\n") + progressReset.m_LogText, _T("TortoiseGit"), MB_OK | MB_ICONQUESTION);
+			
 			if(isStash)
 				askIfUserWantsToStashPop();
 

--- a/src/TortoiseProc/Commands/SVNRebaseCommand.h
+++ b/src/TortoiseProc/Commands/SVNRebaseCommand.h
@@ -18,6 +18,7 @@
 //
 #pragma once
 #include "Command.h"
+#include "ProgressDlg.h"
 
 /**
  * \ingroup TortoiseProc
@@ -26,7 +27,7 @@
 class SVNRebaseCommand : public Command
 {
 private:
-	void	askIfUserWantsToStashPop();
+	void	askIfUserWantsToStashPop(bool autoPopIngore, bool autoPopStash, GitProgressAutoClose autoClose);
 
 public:
 	/**


### PR DESCRIPTION
SVNRebaseCommand should not stop execution when closeonend is set for closing with no errors.

https://tortoisegit.org/issue/2781