### PR TITLE
Add U and D keyboard shortcuts in rebase dialog

### DIFF
--- a/src/TortoiseProc/RebaseDlg.cpp
+++ b/src/TortoiseProc/RebaseDlg.cpp
@@ -825,6 +825,20 @@ BOOL CRebaseDlg::PreTranslateMessage(MSG*pMsg)
 				return TRUE;
 			}
 			break;
+		case 'U':
+			if (LogListHasFocus(pMsg->hwnd))
+			{
+				OnBnClickedButtonDown2();
+				return TRUE;
+			}
+			break;
+		case 'D':
+			if (LogListHasFocus(pMsg->hwnd))
+			{
+				OnBnClickedButtonUp2();
+				return TRUE;
+			}
+			break;
 		case 'A':
 			if(LogListHasFocus(pMsg->hwnd) && GetAsyncKeyState(VK_CONTROL) & 0x8000)
 			{


### PR DESCRIPTION
I use keyboard shortcuts for everything else. The move up / down buttons seem to be lacking them.

I'd settle for having a mnemonic on the button text, but this way the control won't leave focus.
