### PR TITLE
Handle WM_MEASUREITEM message to set owner-drawn combo boxes height properly.

### DIFF
--- a/src/TortoiseMerge/SetMainPage.cpp
+++ b/src/TortoiseMerge/SetMainPage.cpp
@@ -278,6 +278,7 @@ void CSetMainPage::OnMeasureItem(int nIDCtl, LPMEASUREITEMSTRUCT lpMeasureItemSt
 		CSize sz = pDC->GetTextExtent(L"0");
 		lpMeasureItemStruct->itemHeight = sz.cy + 2 * iborder;
 		pDC->SelectObject(pFontPrev);
+		ReleaseDC(pDC);
 	}
 	CPropertyPage::OnMeasureItem(nIDCtl, lpMeasureItemStruct);
 }

--- a/src/TortoiseMerge/SetMainPage.cpp
+++ b/src/TortoiseMerge/SetMainPage.cpp
@@ -229,6 +229,7 @@ BEGIN_MESSAGE_MAP(CSetMainPage, CPropertyPage)
 	ON_BN_CLICKED(IDC_AUTOADD, &CSetMainPage::OnModified)
 	ON_EN_CHANGE(IDC_MAXINLINE, &CSetMainPage::OnModifiedWithReload)
 	ON_BN_CLICKED(IDC_USERIBBONS, &CSetMainPage::OnModified)
+	ON_WM_MEASUREITEM()
 END_MESSAGE_MAP()
 
 
@@ -265,4 +266,18 @@ BOOL CSetMainPage::DialogEnableWindow(UINT nID, BOOL bEnable)
 		SendMessage(WM_NEXTDLGCTL, 0, FALSE);
 	}
 	return pwndDlgItem->EnableWindow(bEnable);
+}
+
+void CSetMainPage::OnMeasureItem(int nIDCtl, LPMEASUREITEMSTRUCT lpMeasureItemStruct)
+{
+	CFont* pFont = GetFont();
+	if (pFont) {
+		CDC* pDC = GetDC();
+		CFont* pFontPrev = pDC->SelectObject(pFont);
+		int iborder = ::GetSystemMetrics(SM_CYBORDER);
+		CSize sz = pDC->GetTextExtent(L"0");
+		lpMeasureItemStruct->itemHeight = sz.cy + 2 * iborder;
+		pDC->SelectObject(pFontPrev);
+	}
+	CPropertyPage::OnMeasureItem(nIDCtl, lpMeasureItemStruct);
 }

--- a/src/TortoiseMerge/SetMainPage.h
+++ b/src/TortoiseMerge/SetMainPage.h
@@ -53,6 +53,7 @@ protected:
 	afx_msg void OnModified();
 	afx_msg void OnModifiedWithReload();
 	afx_msg void OnBnClickedWhitespace();
+	afx_msg void OnMeasureItem(int nIDCtl, LPMEASUREITEMSTRUCT lpMeasureItemStruct);
 
 	DECLARE_MESSAGE_MAP()
 

--- a/src/TortoiseProc/Settings/SetDialogs.cpp
+++ b/src/TortoiseProc/Settings/SetDialogs.cpp
@@ -340,6 +340,7 @@ void CSetDialogs::OnMeasureItem(int nIDCtl, LPMEASUREITEMSTRUCT lpMeasureItemStr
 		CSize sz = pDC->GetTextExtent(L"0");
 		lpMeasureItemStruct->itemHeight = sz.cy + 2 * iborder;
 		pDC->SelectObject(pFontPrev);
+		ReleaseDC(pDC);
 	}
 	ISettingsPropPage::OnMeasureItem(nIDCtl, lpMeasureItemStruct);
 }

--- a/src/TortoiseProc/Settings/SetDialogs.cpp
+++ b/src/TortoiseProc/Settings/SetDialogs.cpp
@@ -134,6 +134,7 @@ BEGIN_MESSAGE_MAP(CSetDialogs, ISettingsPropPage)
 	ON_BN_CLICKED(IDC_DESCRIBEALWAYSLONG, OnChange)
 	ON_BN_CLICKED(IDC_FULLCOMMITMESSAGEONLOGLINE, OnChange)
 	ON_BN_CLICKED(IDC_USEMAILMAP, OnChange)
+	ON_WM_MEASUREITEM()
 END_MESSAGE_MAP()
 
 // CSetDialogs message handlers
@@ -327,4 +328,18 @@ BOOL CSetDialogs::OnApply()
 
 	SetModified(FALSE);
 	return ISettingsPropPage::OnApply();
+}
+
+void CSetDialogs::OnMeasureItem(int nIDCtl, LPMEASUREITEMSTRUCT lpMeasureItemStruct)
+{
+	CFont* pFont = GetFont();
+	if (pFont) {
+		CDC* pDC = GetDC();
+		CFont* pFontPrev = pDC->SelectObject(pFont);
+		int iborder = ::GetSystemMetrics(SM_CYBORDER);
+		CSize sz = pDC->GetTextExtent(L"0");
+		lpMeasureItemStruct->itemHeight = sz.cy + 2 * iborder;
+		pDC->SelectObject(pFontPrev);
+	}
+	ISettingsPropPage::OnMeasureItem(nIDCtl, lpMeasureItemStruct);
 }

--- a/src/TortoiseProc/Settings/SetDialogs.h
+++ b/src/TortoiseProc/Settings/SetDialogs.h
@@ -50,6 +50,7 @@ protected:
 	afx_msg void OnChange();
 	afx_msg void OnCbnSelchangeDefaultlogscale();
 	afx_msg void OnBnClickedBrowsecheckoutpath();
+	afx_msg void OnMeasureItem(int nIDCtl, LPMEASUREITEMSTRUCT lpMeasureItemStruct);
 
 private:
 	BOOL				m_bShortDateFormat;

--- a/src/TortoiseProc/Settings/SettingsTBlame.cpp
+++ b/src/TortoiseProc/Settings/SettingsTBlame.cpp
@@ -288,6 +288,7 @@ void CSettingsTBlame::OnMeasureItem(int nIDCtl, LPMEASUREITEMSTRUCT lpMeasureIte
 		CSize sz = pDC->GetTextExtent(L"0");
 		lpMeasureItemStruct->itemHeight = sz.cy + 2 * iborder;
 		pDC->SelectObject(pFontPrev);
+		ReleaseDC(pDC);
 	}
 	ISettingsPropPage::OnMeasureItem(nIDCtl, lpMeasureItemStruct);
 }

--- a/src/TortoiseProc/Settings/SettingsTBlame.cpp
+++ b/src/TortoiseProc/Settings/SettingsTBlame.cpp
@@ -101,6 +101,7 @@ BEGIN_MESSAGE_MAP(CSettingsTBlame, ISettingsPropPage)
 	ON_BN_CLICKED(IDC_FOLLOWRENAMES, OnChange)
 	ON_BN_CLICKED(IDC_NEWLINESCOLOR, &CSettingsTBlame::OnBnClickedColor)
 	ON_BN_CLICKED(IDC_OLDLINESCOLOR, &CSettingsTBlame::OnBnClickedColor)
+	ON_WM_MEASUREITEM()
 END_MESSAGE_MAP()
 
 
@@ -276,3 +277,18 @@ void CSettingsTBlame::UpdateDependencies()
 	GetDlgItem(IDC_SHOWCOMPLETELOG)->EnableWindow(enableShowCompleteLog);
 	GetDlgItem(IDC_FOLLOWRENAMES)->EnableWindow(enableFollowRenames);
 }
+
+void CSettingsTBlame::OnMeasureItem(int nIDCtl, LPMEASUREITEMSTRUCT lpMeasureItemStruct)
+{
+	CFont* pFont = GetFont();
+	if (pFont) {
+		CDC* pDC = GetDC();
+		CFont* pFontPrev = pDC->SelectObject(pFont);
+		int iborder = ::GetSystemMetrics(SM_CYBORDER);
+		CSize sz = pDC->GetTextExtent(L"0");
+		lpMeasureItemStruct->itemHeight = sz.cy + 2 * iborder;
+		pDC->SelectObject(pFontPrev);
+	}
+	ISettingsPropPage::OnMeasureItem(nIDCtl, lpMeasureItemStruct);
+}
+

--- a/src/TortoiseProc/Settings/SettingsTBlame.h
+++ b/src/TortoiseProc/Settings/SettingsTBlame.h
@@ -46,6 +46,7 @@ protected:
 	afx_msg void OnBnClickedColor();
 	afx_msg void OnChange();
 	afx_msg void OnBnClickedRestore();
+	afx_msg void OnMeasureItem(int nIDCtl, LPMEASUREITEMSTRUCT lpMeasureItemStruct);
 
 	void UpdateDependencies();
 

--- a/src/TortoiseProc/Settings/SettingsTUDiff.cpp
+++ b/src/TortoiseProc/Settings/SettingsTUDiff.cpp
@@ -254,6 +254,7 @@ void CSettingsUDiff::OnMeasureItem(int nIDCtl, LPMEASUREITEMSTRUCT lpMeasureItem
 		CSize sz = pDC->GetTextExtent(L"0");
 		lpMeasureItemStruct->itemHeight = sz.cy + 2 * iborder;
 		pDC->SelectObject(pFontPrev);
+		ReleaseDC(pDC);
 	}
 	ISettingsPropPage::OnMeasureItem(nIDCtl, lpMeasureItemStruct);
 }

--- a/src/TortoiseProc/Settings/SettingsTUDiff.cpp
+++ b/src/TortoiseProc/Settings/SettingsTUDiff.cpp
@@ -99,6 +99,7 @@ BEGIN_MESSAGE_MAP(CSettingsUDiff, ISettingsPropPage)
 	ON_BN_CLICKED(IDC_BACKCOMMENTCOLOR, &CSettingsUDiff::OnBnClickedColor)
 	ON_BN_CLICKED(IDC_BACKADDEDCOLOR, &CSettingsUDiff::OnBnClickedColor)
 	ON_BN_CLICKED(IDC_BACKREMOVEDCOLOR, &CSettingsUDiff::OnBnClickedColor)
+	ON_WM_MEASUREITEM()
 END_MESSAGE_MAP()
 
 // CSettingsUDiff message handlers
@@ -241,4 +242,18 @@ BOOL CSettingsUDiff::OnApply()
 void CSettingsUDiff::OnBnClickedColor()
 {
 	SetModified();
+}
+
+void CSettingsUDiff::OnMeasureItem(int nIDCtl, LPMEASUREITEMSTRUCT lpMeasureItemStruct)
+{
+	CFont* pFont = GetFont();
+	if (pFont) {
+		CDC* pDC = GetDC();
+		CFont* pFontPrev = pDC->SelectObject(pFont);
+		int iborder = ::GetSystemMetrics(SM_CYBORDER);
+		CSize sz = pDC->GetTextExtent(L"0");
+		lpMeasureItemStruct->itemHeight = sz.cy + 2 * iborder;
+		pDC->SelectObject(pFontPrev);
+	}
+	ISettingsPropPage::OnMeasureItem(nIDCtl, lpMeasureItemStruct);
 }

--- a/src/TortoiseProc/Settings/SettingsTUDiff.h
+++ b/src/TortoiseProc/Settings/SettingsTUDiff.h
@@ -45,6 +45,7 @@ protected:
 	afx_msg void OnBnClickedColor();
 	afx_msg void OnChange();
 	afx_msg void OnBnClickedRestore();
+	afx_msg void OnMeasureItem(int nIDCtl, LPMEASUREITEMSTRUCT lpMeasureItemStruct);
 
 	DECLARE_MESSAGE_MAP()
 private:


### PR DESCRIPTION
Hi, this PR fixes the problem that owner-drawn combo boxes are not fully displayed on High DPI screens.

This is the example picture.
![ss](https://cloud.githubusercontent.com/assets/1131125/21078436/127cd8de-bfb2-11e6-8e47-d246a75145c9.png)

