### PR TITLE
Remove redundant get when accessing element in unique_ptr array

### DIFF
--- a/src/Git/TGitPath.cpp
+++ b/src/Git/TGitPath.cpp
@@ -767,7 +767,7 @@ bool CTGitPath::HasStashDir(const CString& dotGitPath) const
 	DWORD size = 0;
 	auto buff = std::make_unique<char[]>(filesize + 1);
 	ReadFile(hfile, buff.get(), filesize, &size, nullptr);
-	buff.get()[filesize] = '\0';
+	buff[filesize] = '\0';
 
 	if (size != filesize)
 		return false;

--- a/src/ResText/POFile.cpp
+++ b/src/ResText/POFile.cpp
@@ -77,7 +77,7 @@ BOOL CPOFile::ParseFile(LPCTSTR szPath, BOOL bUpdateExisting, bool bAdjustEOLs)
 	do
 	{
 		File.getline(line.get(), 2*MAX_STRING_LENGTH);
-		if (line.get()[0]==0)
+		if (line[0]==0)
 		{
 			//empty line means end of entry!
 			RESOURCEENTRY resEntry = {0};

--- a/src/TortoiseMerge/BaseView.cpp
+++ b/src/TortoiseMerge/BaseView.cpp
@@ -1934,7 +1934,7 @@ void CBaseView::DrawTextLine(
 					do
 					{
 						int middle = (upper + lower + 1) / 2;
-						int width = posBuffer.get()[middle];
+						int width = posBuffer[middle];
 						if (rc.left - nLeft < width)
 							upper = middle - 1;
 						else
@@ -1943,7 +1943,7 @@ void CBaseView::DrawTextLine(
 
 					offset = lower;
 					nTextLength -= offset;
-					leftcoord += lower > 0 ? posBuffer.get()[lower - 1] : 0;
+					leftcoord += lower > 0 ? posBuffer[lower - 1] : 0;
 				}
 
 				pDC->ExtTextOut(leftcoord, coords.y, ETO_CLIPPED, &rc, p_zBlockText + offset, min(nTextLength, 4094), nullptr);
@@ -3765,7 +3765,7 @@ int CBaseView::CalcColFromPoint(int xpos, int lineIndex)
 		do
 		{
 			int middle = (upper + lower + 1) / 2;
-			int width = posBuffer.get()[middle];
+			int width = posBuffer[middle];
 			if (xcheck < width)
 				upper = middle - 1;
 			else
@@ -3775,8 +3775,8 @@ int CBaseView::CalcColFromPoint(int xpos, int lineIndex)
 		xpos2 = lower;
 		if (lower < fit - 1)
 		{
-			int charWidth = posBuffer.get()[lower] - (lower > 0 ? posBuffer.get()[lower - 1] : 0);
-			if (posBuffer.get()[lower] - xcheck <= charWidth / 2)
+			int charWidth = posBuffer[lower] - (lower > 0 ? posBuffer[lower - 1] : 0);
+			if (posBuffer[lower] - xcheck <= charWidth / 2)
 				xpos2++;
 		}
 	}

--- a/src/TortoiseProc/RebaseDlg.cpp
+++ b/src/TortoiseProc/RebaseDlg.cpp
@@ -2569,16 +2569,16 @@ void CRebaseDlg::OnBnClickedButtonDown()
 	auto indexes = std::make_unique<int[]>(m_CommitList.GetSelectedCount());
 	int i = 0;
 	while(pos)
-		indexes.get()[i++] = m_CommitList.GetNextSelectedItem(pos);
+		indexes[i++] = m_CommitList.GetNextSelectedItem(pos);
 	// don't move any item if the last selected item is the last item in the m_CommitList
 	// (that would change the order of the selected items)
-	if (!moveToBottom && indexes.get()[m_CommitList.GetSelectedCount() - 1] >= m_CommitList.GetItemCount() - 1)
+	if (!moveToBottom && indexes[m_CommitList.GetSelectedCount() - 1] >= m_CommitList.GetItemCount() - 1)
 		return;
 	int count = m_CommitList.GetItemCount() - 1;
 	// iterate over the indexes backwards in order to correctly move multiselected items
 	for (i = m_CommitList.GetSelectedCount() - 1; i >= 0; i--)
 	{
-		int index = indexes.get()[i];
+		int index = indexes[i];
 		count = moveToBottom ? count : (index + 1);
 		while (index < count)
 		{
@@ -2593,7 +2593,7 @@ void CRebaseDlg::OnBnClickedButtonDown()
 		}
 		count--;
 	}
-	m_CommitList.EnsureVisible(indexes.get()[m_CommitList.GetSelectedCount() - 1] + 1, false);
+	m_CommitList.EnsureVisible(indexes[m_CommitList.GetSelectedCount() - 1] + 1, false);
 	if (changed)
 	{
 		m_CommitList.Invalidate();

--- a/src/TortoiseProc/UpdateCrypto.cpp
+++ b/src/TortoiseProc/UpdateCrypto.cpp
@@ -823,7 +823,7 @@ static int check_hash(HCRYPTHASH hHash, signature_packet_t *p_sig)
 	auto pHash = std::make_unique<BYTE[]>(hashLen);
 	CryptGetHashParam(hHash, HP_HASHVAL, pHash.get(), &hashLen, 0);
 
-	if (pHash.get()[0] != p_sig->hash_verification[0] || pHash.get()[1] != p_sig->hash_verification[1])
+	if (pHash[0] != p_sig->hash_verification[0] || pHash[1] != p_sig->hash_verification[1])
 		return -1;
 
 	return 0;

--- a/src/Utils/BugTraqAssociations.cpp
+++ b/src/Utils/BugTraqAssociations.cpp
@@ -79,7 +79,7 @@ void CBugTraqAssociations::Load(LPCTSTR uuid /* = nullptr */, LPCTSTR params /* 
 			RegQueryValueEx(hk2, L"Parameters", nullptr, nullptr, nullptr, &cbParameters);
 			auto szParameters = std::make_unique<TCHAR[]>(cbParameters + 1);
 			RegQueryValueEx(hk2, L"Parameters", nullptr, nullptr, (LPBYTE)szParameters.get(), &cbParameters);
-			szParameters.get()[cbParameters] = 0;
+			szParameters[cbParameters] = 0;
 
 			DWORD enabled = TRUE;
 			DWORD size = sizeof(enabled);

--- a/src/Utils/TaskbarUUID.cpp
+++ b/src/Utils/TaskbarUUID.cpp
@@ -177,12 +177,12 @@ void SetUUIDOverlayIcon( HWND hWnd )
         // AND mask - monochrome - determines which pixels get drawn
         auto AND = std::make_unique<BYTE[]>(iconWidth * iconWidth);
         for (int i = 0; i < iconWidth * iconWidth; ++i)
-            AND.get()[i] = 0xff;
+            AND[i] = 0xff;
 
         // XOR mask - 32bpp ARGB - determines the pixel values
         auto XOR = std::make_unique<DWORD[]>(iconWidth * iconWidth);
         for (int i = 0; i < iconWidth * iconWidth; ++i)
-            XOR.get()[i] = colors[foundUUIDIndex % 6];
+            XOR[i] = colors[foundUUIDIndex % 6];
 
         icon = ::CreateIcon(nullptr, iconWidth, iconHeight, 1, 32, AND.get(), (BYTE*)XOR.get());
     }


### PR DESCRIPTION
I'm a member of the [Pinguem.ru](https://pinguem.ru) competition on finding errors in open source projects. Issue was found with [PVS-Studio](https://www.viva64.com/en/pvs-studio/):
* V527 It is odd that the '\0' value is assigned to 'char' type pointer. Probably meant: *buff.get()[filesize] = '\0'. tgitpath.cpp 770