### PR TITLE
Fix analyzer warning "Pointer was utilized before it was verified against nullptr"

### DIFF
--- a/src/Utils/HwSMTP.cpp
+++ b/src/Utils/HwSMTP.cpp
@@ -859,12 +859,12 @@ BOOL CHwSMTP::SendEmail (
 		// Create a buffer.
 		cbIoBufferLength = Sizes.cbHeader + Sizes.cbMaximumMessage + Sizes.cbTrailer;
 		pbIoBuffer = (PBYTE)LocalAlloc(LMEM_FIXED, cbIoBufferLength);
-		SecureZeroMemory(pbIoBuffer, cbIoBufferLength);
 		if (pbIoBuffer == nullptr)
 		{
 			m_csLastError = L"Could not allocate memory";
 			goto cleanup;
 		}
+		SecureZeroMemory(pbIoBuffer, cbIoBufferLength);
 	}
 
 	if (m_iSecurityLevel <= ssl)

--- a/src/Utils/MiscUI/Picture.cpp
+++ b/src/Utils/MiscUI/Picture.cpp
@@ -338,8 +338,7 @@ bool CPicture::Load(tstring sFilePathName)
 								}
 							}
 						}
-						if (piFormatConverter)
-							piFormatConverter->Release();
+						piFormatConverter->Release();
 					}
 					pSource->Release();
 					pBitmapFrameDecode->Release();


### PR DESCRIPTION
I'm a member of the [Pinguem.ru](https://pinguem.ru) competition on finding errors in open source projects. Issue was found with [PVS-Studio](https://www.viva64.com/en/pvs-studio/):
* V595 The 'pbIoBuffer' pointer was utilized before it was verified against nullptr. Check lines: 862, 863. hwsmtp.cpp 862
* V595 The 'piFormatConverter' pointer was utilized before it was verified against nullptr. Check lines: 324, 341. picture.cpp 324