### PR TITLE
Faster browsing in Explorer

### DIFF
--- a/src/Git/GitIndex.cpp
+++ b/src/Git/GitIndex.cpp
@@ -297,7 +297,7 @@ bool CGitIndexFileMap::HasIndexChangedOnDisk(const CString& gitdir)
 {
 	__int64 time = -1, size = -1;
 
-	auto pIndex = SafeGet(gitdir);
+	auto pIndex = SafeGetNormalized(CPathUtils::NormalizePath(gitdir));
 
 	if (!pIndex)
 		return true;
@@ -1052,7 +1052,7 @@ int CGitIgnoreList::CheckIgnore(const CString &path, const CString &projectroot,
 
 void CGitHeadFileMap::CheckHeadAndUpdate(const CString& gitdir, bool ignoreCase)
 {
-	SHARED_TREE_PTR ptr = this->SafeGet(gitdir);
+	SHARED_TREE_PTR ptr = this->SafeGetNormalized(CPathUtils::NormalizePath(gitdir));
 
 	if (ptr.get() && !ptr->CheckHeadUpdate())
 		return;

--- a/src/Git/GitStatus.h
+++ b/src/Git/GitStatus.h
@@ -76,9 +76,9 @@ class GitStatus
 {
 public:
 
-	static int GetFileStatus(const CString& gitdir, CString path, git_wc_status2_t& status, BOOL IsFull = FALSE, BOOL isIgnore = TRUE, bool update = true);
-	static int GetDirStatus(const CString& gitdir, const CString& path, git_wc_status_kind* status, BOOL IsFull = false, BOOL IsRecursive = false, BOOL isIgnore = true);
-	static int EnumDirStatus(const CString& gitdir, const CString& path, git_wc_status_kind* dirstatus, FILL_STATUS_CALLBACK callback, void* pData);
+	static int GetFileStatus(const CString& gitdir, const CString& gitdirNormalized, CString path, git_wc_status2_t& status, BOOL IsFull = FALSE, BOOL isIgnore = TRUE, bool update = true);
+	static int GetDirStatus(const CString& gitdir, const CString& gitdirNormalized, const CString& path, git_wc_status_kind* status, BOOL IsFull = false, BOOL IsRecursive = false, BOOL isIgnore = true);
+	static int EnumDirStatus(const CString& gitdir, const CString& gitdirNormalized, const CString& path, git_wc_status_kind* dirstatus, FILL_STATUS_CALLBACK callback, void* pData);
 	static int GetFileList(const CString& path, std::vector<CGitFileName>& list, bool& isRepoRoot, bool ignoreCase);
 	static bool CheckAndUpdateIgnoreFiles(const CString& gitdir, const CString& subpaths, bool isDir);
 	/** Checks whether a file/directory is ignored - does not reload .ignore files */

--- a/src/Git/gitindex.h
+++ b/src/Git/gitindex.h
@@ -84,11 +84,10 @@ public:
 	CGitIndexFileMap() { m_critIndexSec.Init(); }
 	~CGitIndexFileMap() { m_critIndexSec.Term(); }
 
-	SHARED_INDEX_PTR SafeGet(const CString& path)
+	SHARED_INDEX_PTR SafeGetNormalized(const CString& pathNormalized)
 	{
-		CString thePath(CPathUtils::NormalizePath(path));
 		CAutoLocker lock(m_critIndexSec);
-		auto lookup = find(thePath);
+		auto lookup = find(pathNormalized);
 		if (lookup == cend())
 			return SHARED_INDEX_PTR();
 		return lookup->second;
@@ -196,11 +195,10 @@ public:
 	CGitHeadFileMap() { m_critTreeSec.Init(); }
 	~CGitHeadFileMap() { m_critTreeSec.Term(); }
 
-	SHARED_TREE_PTR SafeGet(const CString& path)
+	SHARED_TREE_PTR SafeGetNormalized(const CString& pathNormalized)
 	{
-		CString thePath(CPathUtils::NormalizePath(path));
 		CAutoLocker lock(m_critTreeSec);
-		auto lookup = find(thePath);
+		auto lookup = find(pathNormalized);
 		if (lookup == cend())
 			return SHARED_TREE_PTR();
 		return lookup->second;

--- a/src/TGitCache/CachedDirectory.cpp
+++ b/src/TGitCache/CachedDirectory.cpp
@@ -372,7 +372,7 @@ int CCachedDirectory::EnumFiles(const CTGitPath& path, CString sProjectRoot, con
 	if (!path.IsDirectory())
 	{
 		git_wc_status2_t status = { git_wc_status_none, false, false };
-		if (pStatus->GetFileStatus(sProjectRoot, sSubPath, status, TRUE, true))
+		if (pStatus->GetFileStatus(sProjectRoot, CPathUtils::NormalizePath(sProjectRoot), sSubPath, status, TRUE, true))
 		{
 			// we could not get the status of a file, try whole directory after a short delay if the whole directory was not already crawled with an error
 			if (m_currentFullStatus == git_wc_status_none)
@@ -397,7 +397,7 @@ int CCachedDirectory::EnumFiles(const CTGitPath& path, CString sProjectRoot, con
 
 		m_mostImportantFileStatus = git_wc_status_none;
 		git_wc_status_kind folderstatus = git_wc_status_unversioned;
-		if (pStatus->EnumDirStatus(sProjectRoot, sSubPath, &folderstatus, GetStatusCallback, this))
+		if (pStatus->EnumDirStatus(sProjectRoot, CPathUtils::NormalizePath(sProjectRoot), sSubPath, &folderstatus, GetStatusCallback, this))
 			return -1;
 
 		if (isSelf)


### PR DESCRIPTION
TortoiseGit currently normalizes the git directory path repeatedly for every single file that it examines.
This pull request factors out this translation, speeding up browsing in Explorer considerably.
Please merge? :-)