### PR TITLE
Fix U and D keyboard shortcuts in rebase dialog

### DIFF
--- a/src/TortoiseProc/RebaseDlg.cpp
+++ b/src/TortoiseProc/RebaseDlg.cpp
@@ -854,14 +854,14 @@ BOOL CRebaseDlg::PreTranslateMessage(MSG*pMsg)
 		case 'U':
 			if (LogListHasFocus(pMsg->hwnd))
 			{
-				OnBnClickedButtonDown();
+				OnBnClickedButtonUp();
 				return TRUE;
 			}
 			break;
 		case 'D':
 			if (LogListHasFocus(pMsg->hwnd))
 			{
-				OnBnClickedButtonUp();
+				OnBnClickedButtonDown();
 				return TRUE;
 			}
 			break;


### PR DESCRIPTION
Not sure how I inverted this on my first attempt in #202, but here's a fix.
