### PR TITLE
Updated to add local changes ignored files when updating status list

### DIFF
--- a/src/Git/GitStatusListCtrl.cpp
+++ b/src/Git/GitStatusListCtrl.cpp
@@ -637,6 +637,9 @@ void CGitStatusListCtrl::Show(unsigned int dwShow, unsigned int dwCheck /*=0*/, 
 
 			for (int i = 0; i < m_IgnoreFileList.GetCount(); ++i)
 				m_arStatusArray.push_back(&m_IgnoreFileList[i]);
+
+			for (int i = 0; i < m_LocalChangesIgnoredFileList.GetCount(); ++i)
+				m_arStatusArray.push_back(&m_LocalChangesIgnoredFileList[i]);
 		}
 		PrepareGroups();
 		m_arListArray.clear();


### PR DESCRIPTION
Calling **CGitStatusListCtrl::Show** causes ignore local changes files to disappear form files list when **UpdateStatusList**  parameter is set to TRUE, this doesn't happen when **UpdateStatusList**  parameter is set to FALSE. 
This is because **m_arStatusArray** items that were added by **CGitStatusListCtrl::UpdateLocalChangesIgnoredFileList** method are removed and not added back.
