### PR TITLE
Support disable "Working Tree Changes" in show log dialog

### DIFF
--- a/src/TortoiseProc/LogDlg.cpp
+++ b/src/TortoiseProc/LogDlg.cpp
@@ -323,7 +323,7 @@ BOOL CLogDlg::OnInitDialog()
 
 	m_LogList.m_Path=m_path;
 	m_LogList.m_hasWC = !GitAdminDir::IsBareRepo(g_Git.m_CurrentDir);
-	m_LogList.m_bShowWC = m_LogList.m_hasWC && m_bShowWC;
+	m_LogList.m_bShowWC = !!CRegDWORD(L"Software\\TortoiseGit\\LogIncludeWorkingTreeChanges", TRUE) && m_LogList.m_hasWC && m_bShowWC;
 	m_LogList.InsertGitColumn();
 
 	if (m_bWholeProject)

--- a/src/TortoiseProc/Settings/SettingsAdvanced.cpp
+++ b/src/TortoiseProc/Settings/SettingsAdvanced.cpp
@@ -94,6 +94,10 @@ CSettingsAdvanced::CSettingsAdvanced()
 	settings[i].type	= CSettingsAdvanced::SettingTypeBoolean;
 	settings[i++].def.b	= false;
 
+	settings[i].sName	= L"LogIncludeWorkingTreeChanges";
+	settings[i].type	= CSettingsAdvanced::SettingTypeBoolean;
+	settings[i++].def.b	= true;
+
 	settings[i].sName	= L"LogShowSuperProjectSubmodulePointer";
 	settings[i].type	= CSettingsAdvanced::SettingTypeBoolean;
 	settings[i++].def.b	= true;
@@ -178,7 +182,7 @@ CSettingsAdvanced::CSettingsAdvanced()
 	settings[i].type	= CSettingsAdvanced::SettingTypeNumber;
 	settings[i++].def.l	= 10 * 1024;
 
-    settings[i].sName	= L"UseCustomWordBreak";
+	settings[i].sName	= L"UseCustomWordBreak";
 	settings[i].type	= CSettingsAdvanced::SettingTypeNumber;
 	settings[i++].def.l = 2;
 


### PR DESCRIPTION
When using network drives (ex. samba), show log will hang for big project because of large of files.
Adding Flag for disabling Working Tree Changes in show log dialog can solve it.
It can speedup log show when using network drives