### PR TITLE
fix "MERGE STRATEGIES" link on doc

### DIFF
--- a/doc/source/en/TortoiseGit/git_doc/git-cherry-pick.xml
+++ b/doc/source/en/TortoiseGit/git_doc/git-cherry-pick.xml
@@ -263,8 +263,8 @@ effect to your index in a row.</simpara>
 <listitem>
 <simpara>
         Use the given merge strategy.  Should only be used once.
-        See the MERGE STRATEGIES section in <xref linkend="git-merge(1)" />
-        for details.
+        See <xref linkend="git-merge(1)__merge_strategies" /> under the 
+		<xref linkend="git-merge(1)" /> section, for details.
 </simpara>
 </listitem>
 </varlistentry>

--- a/doc/source/en/TortoiseGit/git_doc/git-config.xml
+++ b/doc/source/en/TortoiseGit/git_doc/git-config.xml
@@ -5391,8 +5391,8 @@ notes.mergeStrategy
 <simpara>
         Which merge strategy to choose by default when resolving notes
         conflicts.  Must be one of <emphasis>manual</emphasis>, <emphasis>ours</emphasis>, <emphasis>theirs</emphasis>, <emphasis>union</emphasis>, or
-        <emphasis>cat_sort_uniq</emphasis>.  Defaults to <emphasis>manual</emphasis>.  See "NOTES MERGE STRATEGIES"
-        section of <xref linkend="git-notes(1)" /> for more information on each strategy.
+        <emphasis>cat_sort_uniq</emphasis>.  Defaults to <emphasis>manual</emphasis>.  See <xref linkend="git-notes(1)__notes_merge_strategies" />
+        section for more information on each strategy.
 </simpara>
 </listitem>
 </varlistentry>
@@ -5404,8 +5404,8 @@ notes.&lt;name&gt;.mergeStrategy
 <simpara>
         Which merge strategy to choose when doing a notes merge into
         refs/notes/&lt;name&gt;.  This overrides the more general
-        "notes.mergeStrategy".  See the "NOTES MERGE STRATEGIES" section in
-        <xref linkend="git-notes(1)" /> for more information on the available strategies.
+        "notes.mergeStrategy".  See the <xref linkend="git-notes(1)__notes_merge_strategies" /> section 
+        for more information on the available strategies.
 </simpara>
 </listitem>
 </varlistentry>

--- a/doc/source/en/TortoiseGit/git_doc/git-revert.xml
+++ b/doc/source/en/TortoiseGit/git_doc/git-revert.xml
@@ -159,7 +159,7 @@ effect to your index in a row.</simpara>
 <listitem>
 <simpara>
         Use the given merge strategy.  Should only be used once.
-        See the MERGE STRATEGIES section in <xref linkend="git-merge(1)" />
+        See the <xref linkend="git-merge(1)__merge_strategies" /> section in <xref linkend="git-merge(1)" />
         for details.
 </simpara>
 </listitem>


### PR DESCRIPTION
make a direct links of "MERGE STRATEGIES" section instead of a manual navigation instractions