### PR TITLE
Fixed issue #3636: Commit Window new branch should focus textbox.

### DIFF
--- a/src/Changelog.txt
+++ b/src/Changelog.txt
@@ -31,6 +31,7 @@ Released: unreleased
  * Update libgit2 to 1.0
  * Implement very simple multi-project pull/fetch/push
  * Fixed issue #3183: Add support for git lfs lock/unlock
+ * Fixed issue #3636: Commit Window new branch should focus textbox
 
 = Release 2.10.0.2 =
 Released: 2020-03-24

--- a/src/TortoiseProc/CommitDlg.cpp
+++ b/src/TortoiseProc/CommitDlg.cpp
@@ -2815,6 +2815,8 @@ void CCommitDlg::OnBnClickedCheckNewBranch()
 	{
 		GetDlgItem(IDC_COMMIT_TO)->ShowWindow(SW_HIDE);
 		GetDlgItem(IDC_NEWBRANCH)->ShowWindow(SW_SHOW);
+		GetDlgItem(IDC_NEWBRANCH)->SetFocus();
+		GetDlgItem(IDC_NEWBRANCH)->SendMessage(EM_SETSEL, 0, -1);
 	}
 	else
 	{


### PR DESCRIPTION
Adds SetFocus() call after toggling from commit-to label to new-branch text box.

Signed-off-by: Bill Robertson <theman@fdrsucks.com>