### PR TITLE
Fixed uninitialized field

### DIFF
--- a/src/Utils/MiscUI/HistoryCombo.cpp
+++ b/src/Utils/MiscUI/HistoryCombo.cpp
@@ -42,6 +42,7 @@ CHistoryCombo::CHistoryCombo(BOOL bAllowSortStyle /*=FALSE*/ )
 	, m_bWantReturn(FALSE)
 	, m_bTrim(TRUE)
 	, m_bCaseSensitive(FALSE)
+	, m_bCheckDuplicate(TRUE)
 {
 	SecureZeroMemory(&m_ToolInfo, sizeof(m_ToolInfo));
 }


### PR DESCRIPTION
Uninitialized field causes duplicate entries in combo controls in Format Patch dialog and probably in other locations too.