### PR TITLE
ShellCache: Fix IsContextPathAllowed() to use latest configuration

### DIFF
--- a/src/TortoiseShell/ShellCache.cpp
+++ b/src/TortoiseShell/ShellCache.cpp
@@ -461,25 +461,28 @@ BOOL ShellCache::HasGITAdminDir(LPCTSTR path, BOOL bIsDir, CString* ProjectTopDi
 
 void ShellCache::ExcludeContextValid()
 {
-	if (RefreshIfNeeded())
+	// Lock must be taken by caller, which is done by IsContextPathAllowed()
+	RefreshIfNeeded();
+	if (excludecontextstr.compare(nocontextpaths) == 0)
+		return;
+
+	excludecontextstr = nocontextpaths;
+	excontextvector.clear();
+	size_t pos = 0, pos_ant = 0;
+	pos = excludecontextstr.find(L'\n', pos_ant);
+	while (pos != tstring::npos)
 	{
-		Locker lock(m_critSec);
-		if (excludecontextstr.compare(nocontextpaths) == 0)
-			return;
-		excludecontextstr = nocontextpaths;
-		excontextvector.clear();
-		size_t pos = 0, pos_ant = 0;
-		pos = excludecontextstr.find(L'\n', pos_ant);
-		while (pos != tstring::npos)
-		{
-			tstring token = excludecontextstr.substr(pos_ant, pos - pos_ant);
+		tstring token = excludecontextstr.substr(pos_ant, pos - pos_ant);
+		if (!token.empty())
 			excontextvector.push_back(token);
-			pos_ant = pos + 1;
-			pos = excludecontextstr.find(L'\n', pos_ant);
-		}
-		if (!excludecontextstr.empty())
-			excontextvector.push_back(excludecontextstr.substr(pos_ant, excludecontextstr.size() - 1));
-		excludecontextstr = nocontextpaths;
+		pos_ant = pos + 1;
+		pos = excludecontextstr.find(L'\n', pos_ant);
+	}
+	if (!excludecontextstr.empty())
+	{
+		tstring token = excludecontextstr.substr(pos_ant, excludecontextstr.size() - 1);
+		if (!token.empty())
+			excontextvector.push_back(token);
 	}
 }
 


### PR DESCRIPTION
IsContextPathAllowed() calls ExcludeContextValid() to update excontextvector.
But ExcludeContextValid() almost never do it, since it was checking for
the return of RefreshIfNeeded(). The registry event my have been consumed by
another ShellCache function just before calling ExcludeContextValid().

When starting (When explorer is launched), excludecontextstr and excontextvector
are empty. And they will stay empty forever since the registry is not going to
change (require a setting change I guess).

So remove the return check to RefreshIfNeeded(), which is not needed, there is
already a check to prevent to compute every time excontextvector, .
Also do not take the lock, it was already taken by the caller.
Also do not put inside the vector empty string/pattern.