### PR TITLE
[Issues-3736] Fixed checking for the presence of the "force" key for "LFS unlock" command

### DIFF
--- a/src/Changelog.txt
+++ b/src/Changelog.txt
@@ -1,4 +1,10 @@
-﻿= Release 2.12.0 =
+﻿= Release 2.13.0 =
+Released: unreleased
+
+== Bug Fixes ==
+ * Fixed issue #3736: LFS force unlock not working
+
+= Release 2.12.0 =
 Released: 2021-03-31
 
 == Changes ==

--- a/src/TortoiseProc/Commands/LFSCommands.cpp
+++ b/src/TortoiseProc/Commands/LFSCommands.cpp
@@ -1,6 +1,6 @@
 ﻿// TortoiseGit - a Windows shell extension for easy version control
 
-// Copyright (C) 2019-2020 - TortoiseGit
+// Copyright (C) 2019-2021 - TortoiseGit
 
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -42,7 +42,7 @@ bool LFSLockCommand::Execute()
 
 bool LFSUnlockCommand::Execute()
 {
-	return setLockedState(false, parser.HasVal(L"force"), pathList);
+	return setLockedState(false, parser.HasKey(L"force"), pathList);
 }
 
 bool LFSLocksCommand::Execute()


### PR DESCRIPTION
I published a detailed description of the problem and its reproduction here:
https://gitlab.com/tortoisegit/tortoisegit/-/issues/3736

This pull request solves this problem without affecting the graphical user interface.