### PR TITLE
Dramatically speed up revert operations

### DIFF
--- a/src/Git/Git.h
+++ b/src/Git/Git.h
@@ -1,6 +1,6 @@
 ﻿// TortoiseGit - a Windows shell extension for easy version control
 
-// Copyright (C) 2008-2021 - TortoiseGit
+// Copyright (C) 2008-2022 - TortoiseGit
 
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -40,6 +40,15 @@ constexpr static inline int ConvertVersionToInt(unsigned __int8 major, unsigned 
 {
 	return (major << 24) + (minor << 16) + (patchlevel << 8) + build;
 }
+
+class CTGitRevertBatch
+{
+public:
+	CTGitPathList m_moveList;
+	CTGitPathList m_removeList;
+	CTGitPathList m_checkoutList;
+	CTGitPathList m_addList;
+};
 
 class CFilterData
 {
@@ -282,6 +291,7 @@ private:
 		CGitCall* pcall;
 	} ASYNCREADSTDERRTHREADARGS, *PASYNCREADSTDERRTHREADARGS;
 	CString GetUnifiedDiffCmd(const CTGitPath& path, const CString& rev1, const CString& rev2, bool bMerge, bool bCombine, int diffContext, bool bNoPrefix = false);
+	int PrepareRevertOp(const CString& commit, const CTGitPathList& list, CTGitRevertBatch& batch, CString& err);
 
 public:
 #ifdef _MFC_VER
@@ -313,7 +323,7 @@ public:
 	*/
 	BOOL CheckCleanWorkTree(bool stagedOk = false);
 	BOOL IsResultingCommitBecomeEmpty(bool amend = false);
-	int Revert(const CString& commit, const CTGitPathList &list, CString& err);
+	int Revert(const CString& commit, const CTGitPathList& list, std::function<bool(const CTGitPathList&)> progress, CString& err);
 	int Revert(const CString& commit, const CTGitPath &path, CString& err);
 	int DeleteRef(const CString& reference);
 	/**

--- a/src/Git/GitStatusListCtrl.cpp
+++ b/src/Git/GitStatusListCtrl.cpp
@@ -2675,7 +2675,7 @@ void CGitStatusListCtrl::OnContextMenuList(CWnd * pWnd, CPoint point)
 						CString revertToCommit = L"HEAD";
 						if (m_amend)
 							revertToCommit = L"HEAD~1";
-						if (CString err; g_Git.Revert(revertToCommit, targetList, err))
+						if (CString err; g_Git.Revert(revertToCommit, targetList, [](const CTGitPathList& path) { return true; }, err))
 							MessageBox(L"Revert failed:\n" + err, L"TortoiseGit", MB_ICONERROR);
 						else
 						{

--- a/src/TGitCache/TGitCache.vcxproj
+++ b/src/TGitCache/TGitCache.vcxproj
@@ -75,6 +75,7 @@
     <ClCompile Include="TGITCache.cpp" />
     <ClCompile Include="..\Git\TGitPath.cpp" />
     <ClCompile Include="..\Utils\UnicodeUtils.cpp" />
+    <ClCompile Include="..\Utils\TempFile.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\Git\Git.h" />
@@ -110,6 +111,7 @@
     <ClInclude Include="..\Git\TGitPath.h" />
     <ClInclude Include="..\Utils\UnicodeUtils.h" />
     <ClInclude Include="..\Utils\UniqueQueue.h" />
+    <ClInclude Include="..\Utils\TempFile.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="TGitCache.rc" />

--- a/src/TGitCache/TGitCache.vcxproj.filters
+++ b/src/TGitCache/TGitCache.vcxproj.filters
@@ -102,6 +102,9 @@
     <ClCompile Include="..\Git\GitMailmap.cpp">
       <Filter>Git</Filter>
     </ClCompile>
+    <ClCompile Include="..\Utils\TempFile.cpp">
+      <Filter>Utils</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CachedDirectory.h">
@@ -202,6 +205,9 @@
     </ClInclude>
     <ClInclude Include="..\Git\GitMailmap.h">
       <Filter>Git</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Utils\TempFile.h">
+      <Filter>Utils</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/TGitCache/stdafx.h
+++ b/src/TGitCache/stdafx.h
@@ -7,6 +7,7 @@
 
 #include <SDKDDKVer.h>
 
+#define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
 #define NOMINMAX
 #include <algorithm>
 using std::min;
@@ -37,6 +38,9 @@ using namespace ATL;
 #include <set>
 #include <deque>
 #include <functional>
+#include <iostream>
+#include <fstream>
+#include <codecvt>
 
 #include "git2.h"
 #include "SmartLibgit2Ref.h"

--- a/src/TortoiseGitBlame/stdafx.h
+++ b/src/TortoiseGitBlame/stdafx.h
@@ -15,6 +15,7 @@
 
 #include <SDKDDKVer.h>
 
+#define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
 #define NOMINMAX
 #include <algorithm>
 using std::max;
@@ -58,6 +59,9 @@ using std::min;
 #include <fstream>
 #include <set>
 #include <functional>
+#include <iostream>
+#include <fstream>
+#include <codecvt>
 
 #define USE_GDI_GRADIENT
 #define HISTORYCOMBO_WITH_SYSIMAGELIST

--- a/src/TortoiseMerge/TempFile.h
+++ b/src/TortoiseMerge/TempFile.h
@@ -1,5 +1,6 @@
-// TortoiseGitMerge - a Windows shell extension for easy version control
+﻿// TortoiseGitMerge - a Windows shell extension for easy version control
 
+// Copyright (C) 2008-2022 - TortoiseGit
 // Copyright (C) 2003-2006,2008,2010 - TortoiseSVN
 
 // This program is free software; you can redistribute it and/or
@@ -75,6 +76,7 @@ private:
 
 	// construction / destruction
 
+public:
 	CTempFiles();
 	~CTempFiles();
 };

--- a/src/TortoiseMerge/stdafx.h
+++ b/src/TortoiseMerge/stdafx.h
@@ -12,6 +12,7 @@
 
 #include <SDKDDKVer.h>
 
+#define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
 #define NOMINMAX
 #include <algorithm>
 using std::max;
@@ -52,6 +53,9 @@ using std::min;
 #include <map>
 #include <vector>
 #include <list>
+#include <iostream>
+#include <fstream>
+#include <codecvt>
 
 #pragma warning(push)
 #include "apr_general.h"

--- a/src/TortoiseProc/GitProgressList.cpp
+++ b/src/TortoiseProc/GitProgressList.cpp
@@ -1,6 +1,6 @@
 ﻿// TortoiseGit - a Windows shell extension for easy version control
 
-// Copyright (C) 2008-2021 - TortoiseGit
+// Copyright (C) 2008-2022 - TortoiseGit
 // Copyright (C) 2003-2008 - TortoiseSVN
 
 // This program is free software; you can redistribute it and/or
@@ -147,9 +147,9 @@ svn_wc_conflict_choice_t CGitProgressList::ConflictResolveCallback(const svn_wc_
 #endif
 void CGitProgressList::AddItemToList()
 {
-	int totalcount = GetItemCount();
+	int totalcount = m_arData.size();
 
-	SetItemCountEx(totalcount+1, LVSICF_NOSCROLL|LVSICF_NOINVALIDATEALL);
+	SetItemCountEx(totalcount, LVSICF_NOSCROLL|LVSICF_NOINVALIDATEALL);
 	// make columns width fit
 	if (iFirstResized < 30)
 	{
@@ -491,6 +491,9 @@ UINT CGitProgressList::ProgressThread()
 	KillTimer(TRANSFERTIMER);
 	KillTimer(VISIBLETIMER);
 
+	if (nEnsureVisibleCount)
+		EnsureVisible(GetItemCount() - 1, false);
+
 	if (m_pTaskbarList && m_pPostWnd)
 	{
 		if (DidErrorsOccur())
@@ -710,6 +713,18 @@ bool CGitProgressList::NotificationDataIsAux(const NotificationData* pData)
 	return pData->bAuxItem;
 }
 
+void CGitProgressList::AddNotify(NotificationData** data, int count, CColors::Colors color)
+{
+	if (count == 0)
+		return;
+
+	for (int i = 0; i < count - 1; i++)
+	{
+		m_arData.push_back(data[i]);
+	}
+
+	this->AddNotify(data[count - 1], color);
+}
 void CGitProgressList::AddNotify(NotificationData* data, CColors::Colors color)
 {
 	if (color != CColors::COLOR_END)

--- a/src/TortoiseProc/GitProgressList.h
+++ b/src/TortoiseProc/GitProgressList.h
@@ -1,6 +1,6 @@
 ﻿// TortoiseGit - a Windows shell extension for easy version control
 
-// Copyright (C) 2008-2021 - TortoiseGit
+// Copyright (C) 2008-2022 - TortoiseGit
 // Copyright (C) 2003-2008 - TortoiseSVN
 
 // This program is free software; you can redistribute it and/or
@@ -139,6 +139,7 @@ public:
 	};
 
 	void AddNotify(NotificationData* data, CColors::Colors color = CColors::COLOR_END);
+	void AddNotify(NotificationData** data, int count, CColors::Colors color = CColors::COLOR_END);
 	int UpdateProgress(const git_indexer_progress* stat);
 
 	void SetProgressLabelText(const CString& str);

--- a/src/TortoiseProc/stdafx.h
+++ b/src/TortoiseProc/stdafx.h
@@ -10,6 +10,7 @@
 
 #define _ATL_CSTRING_EXPLICIT_CONSTRUCTORS	// some CString constructors will be explicit
 
+#define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
 #define NOMINMAX
 #include <algorithm>
 using std::max;
@@ -48,6 +49,9 @@ using std::min;
 #include <map>
 #include <set>
 #include <functional>
+#include <iostream>
+#include <fstream>
+#include <codecvt>
 
 #include <vfw.h>
 #include <shlobj.h>

--- a/src/TortoiseShell/TortoiseShell.vcxproj
+++ b/src/TortoiseShell/TortoiseShell.vcxproj
@@ -94,6 +94,7 @@
     <ClCompile Include="..\Git\TGitPath.cpp" />
     <ClCompile Include="TortoiseGIT.cpp" />
     <ClCompile Include="..\Utils\UnicodeUtils.cpp" />
+    <ClCompile Include="..\Utils\TempFile.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="ShellExt.def" />
@@ -119,6 +120,7 @@
     <ClInclude Include="..\Utils\MiscUI\IconBitmapUtils.h" />
     <ClInclude Include="..\Utils\ReaderWriterLock.h" />
     <ClInclude Include="..\Utils\SmartHandle.h" />
+    <ClInclude Include="..\Utils\TempFile.h" />
     <ClInclude Include="ExplorerCommand.h" />
     <ClInclude Include="GITPropertyPage.h" />
     <ClInclude Include="Globals.h" />

--- a/src/TortoiseShell/TortoiseShell.vcxproj.filters
+++ b/src/TortoiseShell/TortoiseShell.vcxproj.filters
@@ -123,6 +123,9 @@
     <ClCompile Include="ExplorerCommand.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\Utils\TempFile.cpp">
+      <Filter>Utils</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="ShellExt.def">
@@ -249,6 +252,9 @@
     </ClInclude>
     <ClInclude Include="ExplorerCommand.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Utils\TempFile.h">
+      <Filter>Utils</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/TortoiseShell/stdafx.h
+++ b/src/TortoiseShell/stdafx.h
@@ -6,6 +6,7 @@
 
 #include <SDKDDKVer.h>
 
+#define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
 #define NOMINMAX
 #include <algorithm>
 using std::max;
@@ -33,6 +34,9 @@ using std::min;
 #include <map>
 #include <vector>
 #include <functional>
+#include <iostream>
+#include <fstream>
+#include <codecvt>
 
 #define CSTRING_AVAILABLE
 

--- a/src/Utils/TempFile.h
+++ b/src/Utils/TempFile.h
@@ -1,6 +1,6 @@
-// TortoiseGit - a Windows shell extension for easy version control
+﻿// TortoiseGit - a Windows shell extension for easy version control
 
-// Copyright (C) 2008, 2012-2013, 2015-2017 - TortoiseGit
+// Copyright (C) 2008, 2012-2013, 2015-2022 - TortoiseGit
 // Copyright (C) 2003-2006,2008,2015 - TortoiseSVN
 
 // This program is free software; you can redistribute it and/or
@@ -29,9 +29,11 @@
 */
 class CTempFiles
 {
-private:
+public:
 	CTempFiles();
 	~CTempFiles();
+
+private:
 	// prevent cloning
 	CTempFiles(const CTempFiles&) = delete;
 	CTempFiles& operator=(const CTempFiles&) = delete;

--- a/test/Cache/Cache.vcxproj
+++ b/test/Cache/Cache.vcxproj
@@ -58,6 +58,7 @@
     <ClCompile Include="..\..\src\Utils\StringUtils.cpp" />
     <ClCompile Include="..\..\src\Git\TGitPath.cpp" />
     <ClCompile Include="..\..\src\Utils\UnicodeUtils.cpp" />
+    <ClCompile Include="..\..\src\Utils\TempFile.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\Git\Git.h" />
@@ -77,6 +78,7 @@
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="..\..\src\Utils\StringUtils.h" />
     <ClInclude Include="..\..\src\Utils\UnicodeUtils.h" />
+    <ClInclude Include="..\..\src\Utils\TempFile.h" />
   </ItemGroup>
   <ItemGroup>
     <Image Include="res\Cache.ico" />

--- a/test/Cache/stdafx.h
+++ b/test/Cache/stdafx.h
@@ -7,6 +7,7 @@
 
 #include <SDKDDKVer.h>
 
+#define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
 #define NOMINMAX
 #include <algorithm>
 using std::min;
@@ -42,6 +43,9 @@ using namespace ATL;
 #include <map>
 #include <deque>
 #include <functional>
+#include <iostream>
+#include <fstream>
+#include <codecvt>
 
 #include "git2.h"
 #include "SmartLibgit2Ref.h"

--- a/test/UnitTests/stdafx.h
+++ b/test/UnitTests/stdafx.h
@@ -7,6 +7,7 @@
 
 #include <SDKDDKVer.h>
 
+#define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
 #define NOMINMAX
 #include <algorithm>
 using std::min;
@@ -41,6 +42,9 @@ using std::max;
 #include <deque>
 #include <set>
 #include <functional>
+#include <iostream>
+#include <fstream>
+#include <codecvt>
 
 #define __WIN32__
 


### PR DESCRIPTION
This adds batching for revert operation which makes large reverts (1000 files or more) survivable for the user.
For me, 1500 file reverts are almost 100x faster (~1.3s down from ~115s).

Thing is, I'm not a C++ developer :)
So I'm not really sure about the style, usage of lambdas, and so on, but I did try my best.

Implementation-wise it looks like using git.exe is the right way to go as it seems that neither gitdll nor libgit2 support git-mv and git-rm

TGitPath change to std::streams stems out of this: I've tried adding MFC to the remaining projects and that didn't go that well.