### PR TITLE
Fixed issue #4070: Documentation typo in Reference Log page

### DIFF
--- a/doc/source/en/TortoiseGit/tgit_dug/dug_reflog.xml
+++ b/doc/source/en/TortoiseGit/tgit_dug/dug_reflog.xml
@@ -7,7 +7,7 @@
 	</indexterm>
 	<?dbhh topicname="HIDD_REFLOG"?>
 	<para>
-		The reference log (RefLog) displays the history of a reference (i.e., it is displayed to which commits it pointed in the past). In can be opened using
+		The reference log (RefLog) displays the history of a reference (i.e., it is displayed to which commits it pointed in the past). It can be opened using
 		<menuchoice>
 			<guimenu>TortoiseGit</guimenu>
 			<guimenuitem>RefLog</guimenuitem>


### PR DESCRIPTION
This improves the reference log page clarity.