### PR TITLE
remove bogus reference to checkout.ico

### DIFF
--- a/src/TortoiseShell/TortoiseShell.vcxproj
+++ b/src/TortoiseShell/TortoiseShell.vcxproj
@@ -152,7 +152,6 @@
     <ClInclude Include="..\Utils\UnicodeUtils.h" />
   </ItemGroup>
   <ItemGroup>
-    <Image Include="..\Resources\checkout.ico" />
     <Image Include="..\Resources\clippaste.ico" />
     <Image Include="..\Resources\copy.ico" />
     <Image Include="..\Resources\menuabout.ico" />

--- a/src/TortoiseShell/TortoiseShell.vcxproj.filters
+++ b/src/TortoiseShell/TortoiseShell.vcxproj.filters
@@ -252,9 +252,6 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <Image Include="..\Resources\checkout.ico">
-      <Filter>Resource Files</Filter>
-    </Image>
     <Image Include="..\Resources\clippaste.ico">
       <Filter>Resource Files</Filter>
     </Image>


### PR DESCRIPTION
There is no such icon file as "checkout.ico", so remove this dangling reference.  Confirmed that TortoiseGit builds fine after removing this reference.