### PR TITLE
Speed up Show Log on huge repositories (e.g. chromium)

### DIFF
--- a/src/TortoiseProc/GitLogListBase.cpp
+++ b/src/TortoiseProc/GitLogListBase.cpp
@@ -2674,7 +2674,9 @@ std::expected<bool, CString> CGitLogListBase::BeginFetchLog()
 	if (mask & CGit::LOG_INFO_FOLLOW)
 		mask &= ~(CGit::LOG_INFO_ALL_BRANCH | CGit::LOG_INFO_BASIC_REFS | CGit::LOG_INFO_LOCAL_BRANCHES);
 
-	std::vector<std::string> cmd = g_Git.GetLogCmd(range, path, mask, &m_Filter, CRegDWORD(L"Software\\TortoiseGit\\LogOrderBy", CGit::LOG_ORDER_TOPOORDER));
+	// Default: CHRONOLOGIAL_REVERSED. No --*-order flag avoids git's topo walk,
+	// which is the main cause of slow Show Log on huge repositories.
+	std::vector<std::string> cmd = g_Git.GetLogCmd(range, path, mask, &m_Filter, CRegDWORD(L"Software\\TortoiseGit\\LogOrderBy", CGit::LOG_ORDER_CHRONOLOGIALREVERSED));
 
 	PostMessage(LVM_SETITEMCOUNT, m_logEntries.size(), LVSICF_NOINVALIDATEALL);
 

--- a/src/TortoiseProc/LogDlgHelper.h
+++ b/src/TortoiseProc/LogDlgHelper.h
@@ -47,15 +47,15 @@ public:
 	{
 		m_pLogCache=pLogCache;
 		m_FirstFreeLane=0;
-		// Default to value set in Registry
-		m_logOrderBy = CRegDWORD(L"Software\\TortoiseGit\\LogOrderBy", CGit::LOG_ORDER_TOPOORDER);
+		// Default to value set in Registry (CHRONOLOGIAL_REVERSED is much faster on huge repos)
+		m_logOrderBy = CRegDWORD(L"Software\\TortoiseGit\\LogOrderBy", CGit::LOG_ORDER_CHRONOLOGIALREVERSED);
 	}
 	CLogDataVector()
 	{
 		m_pLogCache = nullptr;
 		m_FirstFreeLane=0;
-		// Default to value set in Registry
-		m_logOrderBy = CRegDWORD(L"Software\\TortoiseGit\\LogOrderBy", CGit::LOG_ORDER_TOPOORDER);
+		// Default to value set in Registry (CHRONOLOGIAL_REVERSED is much faster on huge repos)
+		m_logOrderBy = CRegDWORD(L"Software\\TortoiseGit\\LogOrderBy", CGit::LOG_ORDER_CHRONOLOGIALREVERSED);
 	}
 	void SetLogCache(CLogCache *pLogCache)
 	{

--- a/src/TortoiseProc/LogOrdering.cpp
+++ b/src/TortoiseProc/LogOrdering.cpp
@@ -44,16 +44,16 @@ BOOL CLogOrdering::OnInitDialog()
 {
 	CStandAloneDialog::OnInitDialog();
 
-	int ind = m_cLogOrdering.AddString(CString(MAKEINTRESOURCE(IDS_LOG_CHRONOLOGICALREVERSEDORDER)));
+	int ind = m_cLogOrdering.AddString(CString(MAKEINTRESOURCE(IDS_LOG_CHRONOLOGICALREVERSEDORDER)) + L" " + CString(MAKEINTRESOURCE(IDS_TORTOISEGITDEFAULT)));
 	m_cLogOrdering.SetItemData(ind, CGit::LOG_ORDER_CHRONOLOGIALREVERSED);
-	ind = m_cLogOrdering.AddString(L"--topo-order " + CString(MAKEINTRESOURCE(IDS_TORTOISEGITDEFAULT)));
+	ind = m_cLogOrdering.AddString(L"--topo-order");
 	m_cLogOrdering.SetItemData(ind, CGit::LOG_ORDER_TOPOORDER);
 	ind = m_cLogOrdering.AddString(L"--date-order");
 	m_cLogOrdering.SetItemData(ind, CGit::LOG_ORDER_DATEORDER);
 	ind = m_cLogOrdering.AddString(L"--author-date-order");
 	m_cLogOrdering.SetItemData(ind, CGit::LOG_ORDER_AUTHORDATEORDER);
 
-	DWORD curOrder = CRegDWORD(L"Software\\TortoiseGit\\LogOrderBy", CGit::LOG_ORDER_TOPOORDER);
+	DWORD curOrder = CRegDWORD(L"Software\\TortoiseGit\\LogOrderBy", CGit::LOG_ORDER_CHRONOLOGIALREVERSED);
 	for (int i = 0; i < m_cLogOrdering.GetCount(); ++i)
 		if (m_cLogOrdering.GetItemData(i) == curOrder)
 			m_cLogOrdering.SetCurSel(i);

--- a/src/TortoiseProc/Settings/SetDialogs.cpp
+++ b/src/TortoiseProc/Settings/SetDialogs.cpp
@@ -125,7 +125,7 @@ BEGIN_MESSAGE_MAP(CSetDialogs, ISettingsPropPage)
 	ON_BN_CLICKED(IDC_ENABLEGRAVATAR, OnChange)
 	ON_EN_CHANGE(IDC_GRAVATARURL, OnChange)
 	ON_BN_CLICKED(IDC_RIGHTSIDEBRANCHESTAGS, OnChange)
-	ON_BN_CLICKED(IDC_SHOWDESCRIBE, OnChange)
+	ON_BN_CLICKED(IDC_SHOWDESCRIBE, OnBnClickedShowDescribe)
 	ON_BN_CLICKED(IDC_SHOWREVCOUNTER, OnChange)
 	ON_CBN_SELCHANGE(IDC_DESCRIBESTRATEGY, OnChange)
 	ON_EN_CHANGE(IDC_DESCRIBEABBREVIATEDSIZE, OnChange)
@@ -272,6 +272,19 @@ BOOL CSetDialogs::OnInitDialog()
 
 void CSetDialogs::OnChange()
 {
+	SetModified();
+}
+
+void CSetDialogs::OnBnClickedShowDescribe()
+{
+	UpdateData();
+	if (m_bShowDescribe)
+	{
+		MessageBox(
+			L"'Show Describe' can be very slow on large repositories.",
+			L"TortoiseGit",
+			MB_ICONWARNING | MB_OK);
+	}
 	SetModified();
 }
 

--- a/src/TortoiseProc/Settings/SetDialogs.h
+++ b/src/TortoiseProc/Settings/SetDialogs.h
@@ -48,6 +48,7 @@ protected:
 	BOOL OnInitDialog() override;
 	BOOL OnApply() override;
 	afx_msg void OnChange();
+	afx_msg void OnBnClickedShowDescribe();
 	afx_msg void OnCbnSelchangeDefaultlogscale();
 	afx_msg void OnMeasureItem(int nIDCtl, LPMEASUREITEMSTRUCT lpMeasureItemStruct);
 


### PR DESCRIPTION
* LogOrderBy default -> CHRONOLOGIAL_REVERSED (skips git's topo walk).
* Show Describe default -> off (sync git describe per selection is slow); warn the user when enabling it.